### PR TITLE
Remove extra bottom space below jwplay videos

### DIFF
--- a/www/styles/site-jw-player-media-display.css
+++ b/www/styles/site-jw-player-media-display.css
@@ -17,3 +17,7 @@
 	top: 0;
 	left: 0;
 }
+
+.video-player > div {
+	vertical-align: bottom;
+}


### PR DESCRIPTION
This stems from the display:inline-block used in the responsive mode of
jwplayer. Setting the inline-block div to have vertical-align:bottom
eliminates this extra space.
