### PR TITLE
Fix account search when SiteAccountSearch subclass has a join clause

### DIFF
--- a/Site/admin/components/Account/Index.php
+++ b/Site/admin/components/Account/Index.php
@@ -116,7 +116,8 @@ class SiteAccountIndex extends AdminSearch
 		$pager->total_records = SwatDB::queryOne(
 			$this->app->db,
 			sprintf(
-				'select count(id) from Account where %s',
+				'select count(1) from Account %s where %s',
+				$search->getJoinClause(),
 				$this->getWhereClause()
 			)
 		);


### PR DESCRIPTION
If the search is subclassed, and the where clause is dependant on the join clause, the index would throw an error on loading the count for the pager. Use the join clause in that query to prevent this. As well, remove the id reference, which is ambigious.
