### PR TITLE
Set public media as public access when copying to CDN.

### DIFF
--- a/Site/dataobjects/SiteMediaCdnTask.php
+++ b/Site/dataobjects/SiteMediaCdnTask.php
@@ -11,7 +11,7 @@ require_once 'Site/exceptions/SiteCdnException.php';
  * A task that should be preformed to a CDN in the near future
  *
  * @package   Site
- * @copyright 2011-2012 silverorange
+ * @copyright 2011-2013 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SiteMediaCdnTask extends SiteCdnTask
@@ -124,6 +124,16 @@ class SiteMediaCdnTask extends SiteCdnTask
 	{
 		return (($this->media instanceof SiteMedia) &&
 			($this->encoding instanceof SiteMediaEncoding));
+	}
+
+	// }}}
+	// {{{ protected function getAccessType()
+
+	protected function getAccessType()
+	{
+		return ($this->media->media_set->private)
+			? 'private'
+			: 'public';
 	}
 
 	// }}}


### PR DESCRIPTION
This will fix https://trac.silverorange.com/ticket/10967

To test, you'll need to re-queue any existing single public and single private video on a site with SiteVideoMedia, and then run the CdnUpdater and check to make sure the access controls are set correctly on the items on S3.

``` sql
-- single binding for public video
select MediaEncodingBinding.media, MediaEncodingBinding.encoding from MediaEncodingBinding where media_set in (select id from MediaSet where MediaSet.private = false) limit 1;

-- single binding for private video
select MediaEncodingBinding.media, MediaEncodingBinding.encoding from MediaEncodingBinding where media_set in (select id from MediaSet where MediaSet.private = true) limit 1;
```
