### PR TITLE
Respect PHP's configured error reporting.

### DIFF
--- a/Site/SiteGearmanApplication.php
+++ b/Site/SiteGearmanApplication.php
@@ -198,7 +198,7 @@ abstract class SiteGearmanApplication extends SiteApplication
 	public function handleError($errno, $errstr, $errfile, $errline, $errcontext)
 	{
 		// respect PHP's configured error handling
-		if (!error_reporting() & $errno) {
+		if ((error_reporting() & $errno) === 0) {
 			return;
 		}
 


### PR DESCRIPTION
The Gearman custom error handler previously handled all error types regardless of the configured error_reporting value.
