### PR TITLE
Add hook to prevent Gearman doing work.

### DIFF
--- a/Site/SiteGearmanApplication.php
+++ b/Site/SiteGearmanApplication.php
@@ -350,6 +350,8 @@ abstract class SiteGearmanApplication extends SiteApplication
 					}
 				}
 			} else {
+				// if we can't do Gearman work, we still want to handle caught
+				// signals so the server can shut down cleanly.
 				if (extension_loaded('pcntl')) {
 					pcntl_signal_dispatch();
 				}


### PR DESCRIPTION
Can be used if a required resource temporarily goes away to stop accepting new jobs until the resource is back.

For example, it the DB or Redis goes down or is restarted it can stop accepting new jobs until the DB or Redis is back.
