### PR TITLE
Fix BOTR api calls in non-instanced admins

### DIFF
--- a/Site/SiteBotrMediaToaster.php
+++ b/Site/SiteBotrMediaToaster.php
@@ -932,9 +932,11 @@ class SiteBotrMediaToaster
 				$this->secret
 			);
 
-			$query_string = sprintf('?exp=%s&sig=%s',
+			$query_string = sprintf(
+				'?exp=%s&sig=%s',
 				$expires,
-				$signature);
+				$signature
+			);
 		}
 
 		$base = ($this->app instanceof SiteWebApplication &&


### PR DESCRIPTION
The secret key is set in SiteBotrMediaToaster::setSecret() and should be used from the internal secret property, not from the application. This occurancance of secret was just missed when those changes took place in 6d7e5b7

To test try previewing a pending video in both an instanced and non-instanced CH admin on zest.
https://blood/course-host/trunk/www/admin/Media/Edit?id=3585
https://blood/course-host-ccme/trunk/www/admin/Media/Edit?id=3585
