### PR TITLE
Fix positioning of overlay content

### DIFF
--- a/www/javascript/site-jw-player-media-display.js
+++ b/www/javascript/site-jw-player-media-display.js
@@ -704,10 +704,10 @@ SiteJwPlayerMediaDisplay.prototype.positionOverlay = function(overlay)
 	var overlay_region = YAHOO.util.Dom.getRegion(overlay);
 	var content_region = YAHOO.util.Dom.getRegion(overlay.firstChild);
 
-	var padding = Math.floor(Math.max(0,
+	var margin = Math.floor(Math.max(0,
 		(overlay_region.height - content_region.height) / 2));
 
-	YAHOO.util.Dom.setStyle(overlay.firstChild, 'padding-top', padding + 'px');
+	YAHOO.util.Dom.setStyle(overlay.firstChild, 'margin-top', margin + 'px');
 };
 
 // }}}


### PR DESCRIPTION
Before, the content could be pushed too low when the video had a % height. Essentials had this issue - see https://blood/essentials/work-{name}/www/account/course/essentials/2012/lecture/opening

Testing is dependent on https://github.com/silverorange/essentials/pull/83

This needs to best tested across our various video sites but should work.
