### PR TITLE
add another container div

### DIFF
--- a/Site/SiteJwPlayerMediaDisplay.php
+++ b/Site/SiteJwPlayerMediaDisplay.php
@@ -265,11 +265,13 @@ class SiteJwPlayerMediaDisplay extends SwatControl
 			}
 		}
 
+		echo '<div class="video-player-container">';
 		echo '<div class="video-player" id="media_display_'.
 			$this->media->id.'">';
 
 		echo '<div id="media_display_container_'.$this->media->id.'"></div>';
 
+		echo '</div>';
 		echo '</div>';
 
 		Swat::displayInlineJavaScript($this->getJavascript());

--- a/www/styles/site-jw-player-media-display.css
+++ b/www/styles/site-jw-player-media-display.css
@@ -1,4 +1,4 @@
-.video-player {
+.video-player-container {
 	position: relative;
 }
 


### PR DESCRIPTION
or else absolutely positioned elements can get cut-off by the `overflow: hidden;` that jwplayer puts on the .video-player div
