### PR TITLE
Fix SiteComment AjaxServer comment saving.

### DIFF
--- a/Site/admin/components/Comment/AjaxServer.php
+++ b/Site/admin/components/Comment/AjaxServer.php
@@ -10,7 +10,7 @@ require_once 'Services/Akismet2.php';
  * Performs actions on comments via AJAX
  *
  * @package   Site
- * @copyright 2009 silverorange
+ * @copyright 2009-2013 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class SiteCommentAjaxServer extends SiteXMLRPCServer
@@ -46,7 +46,7 @@ abstract class SiteCommentAjaxServer extends SiteXMLRPCServer
 
 				$comment->spam = true;
 				$comment->save();
-				$this->flushCache();
+				$comment->postSave($this->app);
 			}
 		}
 
@@ -85,7 +85,7 @@ abstract class SiteCommentAjaxServer extends SiteXMLRPCServer
 
 				$comment->spam = false;
 				$comment->save();
-				$this->flushCache();
+				$comment->postSave($this->app);
 			}
 		}
 

--- a/Site/dataobjects/SiteComment.php
+++ b/Site/dataobjects/SiteComment.php
@@ -9,7 +9,7 @@ require_once 'NateGoSearch/NateGoSearch.php';
  * A comment on a site
  *
  * @package   Site
- * @copyright 2008 silverorange
+ * @copyright 2008-2013 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SiteComment extends SwatDBDataObject
@@ -198,8 +198,9 @@ class SiteComment extends SwatDBDataObject
 	 */
 	public function postSave(SiteApplication $app)
 	{
+		$this->clearCache($app);
+
 		if ($this->status == self::STATUS_PUBLISHED && !$this->spam) {
-			$this->clearCache($app);
 			$this->addToSearchQueue($app);
 		}
 	}


### PR DESCRIPTION
This was updated to call SiteComment's internal cache clearing back in r76399 / 60a314ea38c8956878fd840c6a8329cfde00b93e but marking comments as spam/not spam wasn't correctly updated. Looks like we never noticed this as most spam was caused by Akismit. Calls to mark spam without this just hang.

I also took the liberty of updating postSave() to always call clearCache() to simplfy our calls, and to make sure the cache is cleared in more scenarios.
