### PR TITLE
I don't see why we need to limit this to non-instance sites

### DIFF
--- a/Site/SiteApplication.php
+++ b/Site/SiteApplication.php
@@ -293,7 +293,7 @@ abstract class SiteApplication extends SiteObject
 		static $config_cache = array();
 		$value = null;
 
-		if ($instance !== null &&
+		if ($instance instanceof SiteInstance &&
 			$this->getInstanceId() != $instance->id) {
 
 			if (!isset($config_cache[$instance->id])) {


### PR DESCRIPTION
It can be useful to access the config settings for one instance from another one.
