### PR TITLE
Fix two RTMP fallback issues:

### DIFF
--- a/www/javascript/site-jw-player-media-display.js
+++ b/www/javascript/site-jw-player-media-display.js
@@ -112,11 +112,7 @@ SiteJwPlayerMediaDisplay.prototype.embedPlayer = function()
 		var aspect_ratio = null;
 	}
 
-	var playlist = [{
-		image: this.getImage(),
-		sources: this.getSources(),
-		tracks: this.getTracks()
-	}];
+	var playlist = this.getPlaylist();
 
 	var options = {
 		playlist:    playlist,
@@ -295,10 +291,22 @@ SiteJwPlayerMediaDisplay.prototype.getSources = function()
 			s[k] = this.sources[i][k];
 		}
 
-		sources[i] = s;
+		sources.push(s);
 	}
 
 	return sources;
+};
+
+// }}}
+// {{{ SiteJwPlayerMediaDisplay.prototype.getPlaylist = function()
+
+SiteJwPlayerMediaDisplay.prototype.getPlaylist = function()
+{
+	return [{
+		image: this.getImage(),
+		sources: this.getSources(),
+		tracks: this.getTracks()
+	}];
 };
 
 // }}}
@@ -561,7 +569,7 @@ SiteJwPlayerMediaDisplay.prototype.handleError = function(error)
 				YAHOO.util.Cookie.set(this.location_identifier + '_rtmp_status',
 					'blocked');
 
-				this.player.load(this.getSources());
+				this.player.load(this.getPlaylist());
 				this.player.play();
 			} else {
 				if (YAHOO.env.ua.android) {


### PR DESCRIPTION
1. building the cloned array of sources in getSource() was failing because we were setting the keys to `[i]` which no longer always starts with 0. Instead, push the values into the array. This was breaking JWPlayer when the RTMP source was skipped.
2. Always load the full playlist instead of just the array of sources. We'd lose the .vtt tracks and images without this.
