### PR TITLE
Botr media fixtures

### DIFF
--- a/sql/fixtures/SiteBotrMediaEncoding.sql
+++ b/sql/fixtures/SiteBotrMediaEncoding.sql
@@ -1,0 +1,95 @@
+insert into MediaEncoding (
+	media_set,
+	default_type,
+	title,
+	shortname,
+	default_encoding,
+	width
+) values (
+	(select id from MediaSet where shortname = 'public'),
+	(select id from MediaType where mime_type = 'video/mp4'),
+	'1920-wide (1080p)',
+	'1920',
+	true,
+	1920
+);
+
+insert into MediaEncoding (
+	media_set,
+	default_type,
+	title,
+	shortname,
+	default_encoding,
+	width
+) values (
+	(select id from MediaSet where shortname = 'public'),
+	(select id from MediaType where mime_type = 'video/mp4'),
+	'1280-wide (720p)',
+	'1280',
+	true,
+	1280
+);
+
+insert into MediaEncoding (
+	media_set,
+	default_type,
+	title,
+	shortname,
+	default_encoding,
+	width
+) values (
+	(select id from MediaSet where shortname = 'public'),
+	(select id from MediaType where mime_type = 'video/mp4'),
+	'1080-wide',
+	'1080',
+	true,
+	1080
+);
+
+insert into MediaEncoding (
+	media_set,
+	default_type,
+	title,
+	shortname,
+	default_encoding,
+	width
+) values (
+	(select id from MediaSet where shortname = 'public'),
+	(select id from MediaType where mime_type = 'video/mp4'),
+	'720-wide',
+	'720',
+	true,
+	720
+);
+
+insert into MediaEncoding (
+	media_set,
+	default_type,
+	title,
+	shortname,
+	default_encoding,
+	width
+) values (
+	(select id from MediaSet where shortname = 'public'),
+	(select id from MediaType where mime_type = 'video/mp4'),
+	'480-wide',
+	'480',
+	true,
+	480
+);
+
+insert into MediaEncoding (
+	media_set,
+	default_type,
+	title,
+	shortname,
+	default_encoding,
+	width
+) values (
+	(select id from MediaSet where shortname = 'public'),
+	(select id from MediaType where mime_type = 'video/mp4'),
+	'320-wide (QVGA)',
+	'320',
+	true,
+	320
+);

--- a/sql/fixtures/SiteBotrMediaSet.sql
+++ b/sql/fixtures/SiteBotrMediaSet.sql
@@ -1,0 +1,14 @@
+
+insert into MediaSet (
+	shortname,
+	use_cdn,
+	obfuscate_filename,
+	private,
+	skin
+) values (
+	'public',
+	true,
+	false,
+	false,
+	null
+);

--- a/sql/fixtures/SiteMediaType.sql
+++ b/sql/fixtures/SiteMediaType.sql
@@ -1,0 +1,29 @@
+insert into MediaType (
+	extension,
+	mime_type,
+	alternate_mime_types
+) values (
+	'mp4',
+	'video/mp4',
+	null
+);
+
+insert into MediaType (
+	extension,
+	mime_type,
+	alternate_mime_types
+) values (
+	'm4a',
+	'audio/mp4',
+	'audio/aac, audio/x-m4a, audio/MP4A-LATM, audio/mpeg4-generic'
+);
+
+insert into MediaType (
+	extension,
+	mime_type,
+	alternate_mime_types
+) values (
+	'mp3',
+	'audio/mpeg',
+	'audio/mpeg, audio/mp3, audio/MPA, audio/mpa-robust'
+);


### PR DESCRIPTION
Start with the public media set, and our default media types and encodings. Sites can further customize the media sets they want to use.
