### PR TITLE
Add a minimum suggested size note to the automatic upload.

### DIFF
--- a/Site/admin/components/Image/Upload.php
+++ b/Site/admin/components/Image/Upload.php
@@ -141,7 +141,7 @@ abstract class SiteImageUpload extends AdminObjectEdit
 	}
 
 	// }}}
-	// {{{ protected function initDimensions()
+	// {{{ protected function initDimensionUploadWidgets()
 
 	protected function initDimensionUploadWidgets()
 	{


### PR DESCRIPTION
Minimum suggested size comes from the largest max_width and max_height.

As well, move all dimension note building to the build phase, and clean up a folding bug, and a mistake on the `max_height` only message on individual dimension notes.
