### PR TITLE
Fix saving image dimension file sizes.

### DIFF
--- a/Site/dataobjects/SiteImage.php
+++ b/Site/dataobjects/SiteImage.php
@@ -1264,24 +1264,22 @@ class SiteImage extends SwatDBDataObject
 	protected function saveDimensionBindingFileSize(
 		SiteImageDimension $dimension)
 	{
-		foreach ($this->dimension_bindings as $binding) {
-			if ($binding->dimension == $dimension->id) {
-				// The binding must be duplicated so that saving works
-				// correctly.
-				$binding = $binding->duplicate();
-				$binding->filesize = $this->getDimensionBindingFileSize(
-					$dimension,
-					$binding
-				);
+		$binding = $this->getDimensionBinding($dimension->shortname);
+		if ($binding instanceof SiteImageDimensionBinding) {
+			// Binding has to duplicated or SwatDBDataObject will try to insert
+			// a row using SwatDBDataObject::saveNewBinding() and fail.
+			$binding = $binding->duplicate();
+			$binding->filesize = $this->getDimensionBindingFileSize(
+				$dimension,
+				$binding
+			);
 
-				break;
+			if ($this->automatically_save) {
+				$binding->setDatabase($this->db);
+				$binding->save();
 			}
 		}
 
-		if ($this->automatically_save) {
-			$binding->setDatabase($this->db);
-			$binding->save();
-		}
 	}
 
 	// }}}


### PR DESCRIPTION
This has been broken for YEARS. I noticed it over the file sizes were not saving over a year ago, and did a bunch of debug and traced it back to Imagick not returning a file length or size after the Imagick is cloned. I reported a bug then (https://bugs.php.net/bug.php?id=64015) which pointed the finger at upstream Imagick behaviour. This works around the fact that cloned Imagick instances cannot get filesize by saving a temporary file, loading it again with a new instance, and grabbing the filesize from that.
