### PR TITLE
Remove an unnecessary trim() on the account login page.

### DIFF
--- a/Site/pages/SiteAccountLoginPage.php
+++ b/Site/pages/SiteAccountLoginPage.php
@@ -203,7 +203,7 @@ class SiteAccountLoginPage extends SiteUiPage
 		$href = 'account/forgotpassword';
 
 		$email = $this->ui->getWidget('email_address');
-		if (!$email->hasMessage() && trim($email->value) != '') {
+		if (!$email->hasMessage() && $email->value != '') {
 			$href.= '?email='.urlencode($email->value);
 		}
 


### PR DESCRIPTION
This was added back in 2012 as r76560 / abb680c when the page is restructured, but is unnecessary as SwatEntry auto-trims its values by default since https://github.com/silverorange/swat/commit/994d0032275f0ed5184c7a8f596e29fb449ede22 in 2009, and I can't find any code anywhere that turns that off.
