### PR TITLE
Fix syntax error with the account login relocate

### DIFF
--- a/Site/pages/SiteAccountSessionsPage.php
+++ b/Site/pages/SiteAccountSessionsPage.php
@@ -39,7 +39,7 @@ class SiteAccountSessionsPage extends SiteDBEditPage
 		if (!$this->app->session->isLoggedIn()) {
 			$uri = sprintf(
 				'%s?relocate=%s',
-				$this->app->config->uri->account_login
+				$this->app->config->uri->account_login,
 				$this->source
 			);
 


### PR DESCRIPTION
Introduced in https://github.com/silverorange/site/pull/83
