### PR TITLE
Wrap the button in a span

### DIFF
--- a/Site/pages/SiteAccountSessionsPage.php
+++ b/Site/pages/SiteAccountSessionsPage.php
@@ -551,9 +551,11 @@ class SiteAccountSessionsPage extends SiteDBEditPage
 		echo '</span>';
 
 		if ($logout_button instanceof SwatWidget) {
+			echo '<span class="logout-button-container">';
 			$logout_button->visible = true;
 			$logout_button->display();
 			$logout_button->visible = false;
+			echo '</span>';
 		}
 
 		echo '</li>';


### PR DESCRIPTION
I've tested this in EM:RAP and it still works as before.

This allows bootstrap to set a column for the button to live in without affecting the width of the button.
