### PR TITLE
Make it possible for layouts to override the html head entry set displayer

### DIFF
--- a/Site/SiteHtmlHeadEntrySetDisplayerFactory.php
+++ b/Site/SiteHtmlHeadEntrySetDisplayerFactory.php
@@ -14,7 +14,7 @@ require_once 'Site/SiteApplication.php';
  * the Concentrate library
  *
  * @package   Site
- * @copyright 2010 silverorange
+ * @copyright 2010-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SiteHtmlHeadEntrySetDisplayerFactory

--- a/Site/layouts/SiteLayout.php
+++ b/Site/layouts/SiteLayout.php
@@ -13,7 +13,7 @@ require_once 'Concentrate/CLI.php';
  * Base class for a layout
  *
  * @package   Site
- * @copyright 2005-2012 silverorange
+ * @copyright 2005-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SiteLayout extends SiteObject


### PR DESCRIPTION
This adds a method to `SiteLayout` that can be overridden to specify a different or modified `SwatHtmlHeadEntrySetDisplayer`.
