### PR TITLE
Log DB exceptions on SiteDBEditPage

### DIFF
--- a/Site/pages/SiteDBEditPage.php
+++ b/Site/pages/SiteDBEditPage.php
@@ -7,7 +7,7 @@ require_once 'Site/pages/SiteEditPage.php';
  * Base class for database edit pages
  *
  * @package   Site
- * @copyright 2008-2013 silverorange
+ * @copyright 2008-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class SiteDBEditPage extends SiteEditPage
@@ -55,6 +55,7 @@ abstract class SiteDBEditPage extends SiteEditPage
 
 	protected function handleDBException(SwatDBException $e)
 	{
+		$e->processAndContinue();
 	}
 
 	// }}}


### PR DESCRIPTION
SiteDBEditPage is smart, and rolls back failed DB calls, showing the user a "something went wrong" message. However the exception is just thrown away by default. This means we never get reports of failed queries, and makes development tricky. So instead always process the exception and continue so it gets outputted in development, and logged in production.
