### PR TITLE
Fix a bug related to editing an existing image.

### DIFF
--- a/Site/admin/components/Image/Upload.php
+++ b/Site/admin/components/Image/Upload.php
@@ -39,7 +39,17 @@ abstract class SiteImageUpload extends AdminObjectEdit
 
 	protected function shouldReplaceObject()
 	{
-		return true;
+		// When editing/replacing an existing image, the uploaded file is not
+		// required. This is to allow possible editing of secondary values, such
+		// as individual dimensions if allowDimensionUploads() returns true, or
+		// titles if the title widget is enabled. Only replace the existing
+		// image with a new new object if a new file is uploaded. Otherwise
+		// keep the old version. This does two things - it prevents image churn
+		// on the site/CDN for images that art not actually modified, and it
+		// fixes a bug when cloning a SiteImage where the main dataobject is
+		// copied, but dimension bindings and files on disk are not, leaving
+		// broken images.
+		return ($this->ui->getWidget('upload_widget')->isUploaded());
 	}
 
 	// }}}


### PR DESCRIPTION
SiteImage uploads have always allowed editing the image, without actually replacing the image.

I believe this is primarily to allow editing other fields, such as title if available. Despite the base Site package upload page having no further fields beyond the upload widgets, I've kept this behaviour for easier subclassing and use in existing pages. What this does mean is that we shouldn't replace teh existing object, unless new image is uploaded.
