### PR TITLE
Remove setting the site speed sample rate from the default commands.

### DIFF
--- a/Site/SiteAnalyticsModule.php
+++ b/Site/SiteAnalyticsModule.php
@@ -9,9 +9,10 @@ require_once 'Site/SiteApplicationModule.php';
  * could be added.
  *
  * @package   Site
- * @copyright 2007-2013 silverorange
+ * @copyright 2007-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  * @link      http://code.google.com/apis/analytics/docs/tracking/asyncTracking.html
+ * @todo      Switch to Univeral Analytics, and re-add 100% speed tracking.
  */
 class SiteAnalyticsModule extends SiteApplicationModule
 {


### PR DESCRIPTION
Google's Tag Assistant Chrome Extension complains about the quoted int value. I'm fairly certain it doesn't break anything, but remove it to be on the safe side, as it doesn't lose a huge amount of information in our GA reports. We're going to replace all this code with Universal Analytics soon, and we can re-add the site speed sample rate then.
