### PR TITLE
Don't quote numeric values as strings when building google analytics commands.

### DIFF
--- a/Site/SiteAnalyticsModule.php
+++ b/Site/SiteAnalyticsModule.php
@@ -314,7 +314,7 @@ JS;
 			$method = array_shift($command);
 
 			foreach ($command as $part) {
-				$quoted_part = (is_numeric($part))
+				$quoted_part = (is_float($part) || is_int($part))
 					? $part
 					: SwatString::quoteJavaScriptString($part);
 


### PR DESCRIPTION
This fixes an error Google's Tag Assistant Chrome Extension points out on all our sites when setting _setSiteSpeedSampleRate
