### PR TITLE
Prevent some js errors caused by trying to reposition overlays on hidden players.

### DIFF
--- a/www/javascript/site-jw-player-media-display.js
+++ b/www/javascript/site-jw-player-media-display.js
@@ -828,7 +828,7 @@ SiteJwPlayerMediaDisplay.prototype.positionOverlay = function(overlay)
 
 	// If the overlay is not currently part of the DOM it won't have a region,
 	// so don't try to reposition it.
-	if (!overlay_region) {
+	if (overlay_region) {
 		var content_region = YAHOO.util.Dom.getRegion(overlay.firstChild);
 
 		var margin = Math.floor(


### PR DESCRIPTION
This is most easily triggered by going to a site that shows multiple video players in a playlist (for example Hippo EM lecture pages), and then resizing the window.

Will throw errors without this fix. I noticed this while IE testing the new JwPlayer.
