### PR TITLE
SiteAudio is a subclass of SiteMedia, so make it's wrapper a subclass of SiteMediaWrapper

### DIFF
--- a/Site/dataobjects/SiteAudioMediaWrapper.php
+++ b/Site/dataobjects/SiteAudioMediaWrapper.php
@@ -7,11 +7,11 @@ require_once 'Site/dataobjects/SiteAudioMedia.php';
  * A recordset wrapper class for SiteAudioMedia objects
  *
  * @package   Site
- * @copyright 2011 silverorange
+ * @copyright 2011-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  * @see       SiteAudioMedia
  */
-class SiteAudioMediaWrapper extends SwatDBRecordsetWrapper
+class SiteAudioMediaWrapper extends SiteMediaWrapper
 {
 	// {{{ protected function init()
 


### PR DESCRIPTION
I noticed this while reviewing all wrappers to ensure their indexes were set when reviewing https://github.com/silverorange/site/pull/109
