### PR TITLE
Add method for loading video-only encoding bindings

### DIFF
--- a/Site/SiteHLSIndexGenerator.php
+++ b/Site/SiteHLSIndexGenerator.php
@@ -94,7 +94,7 @@ class SiteHLSIndexGenerator extends SiteCommandLineApplication
 			$media->save();
 		} else {
 			$encodings = $this->getEncodingIndexes($media);
-			if (count($encodings) === count($media->encoding_bindings)) {
+			if (count($encodings) === count($media->video_encoding_bindings)) {
 				$this->writeIndex($media, $encodings);
 				$media->has_hls = true;
 				$media->save();

--- a/Site/dataobjects/SiteVideoMedia.php
+++ b/Site/dataobjects/SiteVideoMedia.php
@@ -427,6 +427,25 @@ class SiteVideoMedia extends SiteMedia
 	}
 
 	// }}}
+	// {{{ protected function loadVideoEncodingBindings()
+
+	protected function loadVideoEncodingBindings()
+	{
+		$sql = sprintf(
+			'select * from MediaEncodingBinding
+			where MediaEncodingBinding.media = %s and height > %s',
+			$this->db->quote($this->id, 'integer'),
+			$this->db->quote(0, 'integer')
+		);
+
+		return SwatDB::query(
+			$this->db,
+			$sql,
+			$this->getMediaEncodingBindingWrapperClass()
+		);
+	}
+
+	// }}}
 }
 
 ?>


### PR DESCRIPTION
I'm using height here the same way we use it to add sources for the JWMediaPlayer