### PR TITLE
Switch 'delete from' to 'truncate'

### DIFF
--- a/Site/SiteNateGoSearchIndexer.php
+++ b/Site/SiteNateGoSearchIndexer.php
@@ -117,7 +117,7 @@ class SiteNateGoSearchIndexer extends SiteSearchIndexer
 		if ($this->clear_cache) {
 			$this->debug(Site::_('Clearing cached search results ... '));
 
-			$sql = 'delete from NateGoSearchCache';
+			$sql = 'truncate NateGoSearchCache';
 			SwatDB::exec($this->db, $sql);
 
 			$this->debug(Site::_('done')."\n");


### PR DESCRIPTION
Since delete from returns a tuple-change number, which explodes pgpool.
This is also faster to wipe a table.