### PR TITLE
Add a relocateWithQueryString() method for convenience

### DIFF
--- a/Site/SiteWebApplication.php
+++ b/Site/SiteWebApplication.php
@@ -735,6 +735,49 @@ class SiteWebApplication extends SiteApplication
 	}
 
 	// }}}
+	// {{{ public function relocateWithQueryString()
+
+	/**
+	 * Relocates to another URI while maintaining the current query string.
+	 *
+	 * This is useful for keeping things like google UTM strings being
+	 * maintained in automatic redirects.
+	 *
+	 * @param string $uri the URI to relocate to.
+	 * @param boolean $secure optional. Whether or not the base href should be
+	 *                         a secure URI. The default value of null
+	 *                         maintains the same security as the current page.
+	 *                         This parameter only has an effect if the
+	 *                         <i>$uri</i> is relative.
+	 * @param boolean $append_sid optional. Whether or not to append the
+	 *                             session identifier to the URI. If null, this
+	 *                             is determined automatically by the
+	 *                             {@link SiteSessionModule::appendSessionId()}
+	 *                             method.
+	 * @param boolean $permanent Whether or not to the relocate is permanent.
+	 *                            Set true for urls that are permanently
+	 *                            moved.
+	 */
+	public function relocateWithQueryString($uri, $secure = null,
+		$append_sid = null, $permanent = false)
+	{
+		$source_uri = parse_url($_SERVER['REQUEST_URI']);
+		$query_string = (isset($source_uri['query']))
+			? $source_uri['query']
+			: '';
+
+		if ($query_string !== '') {
+			$concatenator = (strpos($uri, '?') === false)
+				? '?'
+				: '&';
+
+			$uri.= $concatenator.$query_string;
+		}
+
+		$this->relocate($uri, $secure, $append_sid, $permanent);
+	}
+
+	// }}}
 	// {{{ public function getUri()
 
 	/**

--- a/Site/SiteWebApplication.php
+++ b/Site/SiteWebApplication.php
@@ -708,13 +708,14 @@ class SiteWebApplication extends SiteApplication
 	 *                         This parameter only has an effect if the
 	 *                         <i>$uri</i> is relative.
 	 * @param boolean $append_sid optional. Whether or not to append the
-	 *                             session identifier to the URI. If null, this
-	 *                             is determined automatically by the
+	 *                             session identifier to the URI. If null or
+	 *                             unspecified, this is determined automatically
+	 *                             by the
 	 *                             {@link SiteSessionModule::appendSessionId()}
 	 *                             method.
-	 * @param boolean $permanent Whether or not to the relocate is permanent.
-	 *                            Set true for urls that are permanently
-	 *                            moved.
+	 * @param boolean $permanent optional. Whether or not to the relocate is
+	 *                            permanent. Set true for URIs that are
+	 *                            permanently moved. By default this is false.
 	 */
 	public function relocate($uri, $secure = null, $append_sid = null,
 		$permanent = false)
@@ -750,13 +751,14 @@ class SiteWebApplication extends SiteApplication
 	 *                         This parameter only has an effect if the
 	 *                         <i>$uri</i> is relative.
 	 * @param boolean $append_sid optional. Whether or not to append the
-	 *                             session identifier to the URI. If null, this
-	 *                             is determined automatically by the
+	 *                             session identifier to the URI. If null or
+	 *                             unspecified, this is determined automatically
+	 *                             by the
 	 *                             {@link SiteSessionModule::appendSessionId()}
 	 *                             method.
-	 * @param boolean $permanent Whether or not to the relocate is permanent.
-	 *                            Set true for urls that are permanently
-	 *                            moved.
+	 * @param boolean $permanent optional. Whether or not to the relocate is
+	 *                            permanent. Set true for URIs that are
+	 *                            permanently moved. By default this is false.
 	 */
 	public function relocateWithQueryString($uri, $secure = null,
 		$append_sid = null, $permanent = false)

--- a/Site/SiteWebApplication.php
+++ b/Site/SiteWebApplication.php
@@ -761,12 +761,9 @@ class SiteWebApplication extends SiteApplication
 	public function relocateWithQueryString($uri, $secure = null,
 		$append_sid = null, $permanent = false)
 	{
-		$source_uri = parse_url($_SERVER['REQUEST_URI']);
-		$query_string = (isset($source_uri['query']))
-			? $source_uri['query']
-			: '';
+		$query_string = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
 
-		if ($query_string !== '') {
+		if ($query_string !== null) {
 			$concatenator = (strpos($uri, '?') === false)
 				? '?'
 				: '&';


### PR DESCRIPTION
We use this pattern in a number of places, such a promotion code landing pages where we want to apply a code to the session, and then relocate while maintaining most of the query string passed to the page.