### PR TITLE
Fix typo in variable name.

### DIFF
--- a/Site/admin/SiteCommentDisplay.php
+++ b/Site/admin/SiteCommentDisplay.php
@@ -177,7 +177,7 @@ abstract class SiteCommentDisplay extends SwatControl
 	{
 		$status_span = new SwatHtmlTag('span');
 		$status_span->id = $this->id.'_status';
-		$status_spam->class = 'site-comment-display-status';
+		$status_span->class = 'site-comment-display-status';
 		$status_span->open();
 
 		if ($this->comment->spam) {


### PR DESCRIPTION
https://trello.com/c/UO2jqkCa/612-fix-typo-in-variable-name-causing-php-warning