### PR TITLE
Never display the message at the beginning

### DIFF
--- a/www/javascript/site-jw-player-media-display.js
+++ b/www/javascript/site-jw-player-media-display.js
@@ -668,6 +668,7 @@ SiteJwPlayerMediaDisplay.prototype.drawDialogs = function()
 		this.appendCompleteMessage();
 
 		if (this.display_on_complete_message_on_load &&
+			this.start_position > 0 &&
 			this.start_position > this.duration - 60) {
 			this.displayCompleteMessage();
 		}


### PR DESCRIPTION
This change prevents the on complete message from being displayed on first viewing when the video is less than 60s long.