### PR TITLE
Add module for reporting data to White Chipmunk

### DIFF
--- a/Site/Site.php
+++ b/Site/Site.php
@@ -373,6 +373,11 @@ class Site
 
 			// Olark
 			'olark.site_id' => null,
+
+			// White Chipmunk Tracker
+			'white_chipmunk.enabled' => false,
+			'white_chipmunk.site_shortname' => null,
+			'white_chipmunk.salt' => null,
 		);
 	}
 

--- a/Site/SiteWhiteChipmunkModule.php
+++ b/Site/SiteWhiteChipmunkModule.php
@@ -25,7 +25,7 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 		$this->enabled = $config->white_chipmunk->enabled;
 		$this->cookie_name = sprintf(
 			'%s_chipmunk_uuid',
-			$config->white_chipmunk->shortname
+			$config->white_chipmunk->site_shortname
 		);
 	}
 
@@ -34,9 +34,9 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 
 	public function addConversion($sku, $value)
 	{
-		$this->conversions = array(
-			$sku,
-			$value
+		$this->conversions[] = array(
+			'sku'   => $sku,
+			'value' => $value,
 		);
 	}
 
@@ -59,8 +59,8 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 				$conversions.= sprintf(
 					'&sku%1$s=%2$s&conversionvalue%1$s=%3$s',
 					$count,
-					urlencode($this->sku),
-					urlencode($this->conversion_value)
+					urlencode($conversion['sku']),
+					urlencode($conversion['value'])
 				);
 				$count++;
 			}
@@ -69,7 +69,7 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 				'<div style="display: none;">'.
 				'<img height="1" width="1" border="0" '.
 				'src="https://www.whitechipmunk.com/%s?uid=%s%s%s" /></div>',
-				urlencode($this->app->config->white_chipmunk->shortname),
+				urlencode($this->app->config->white_chipmunk->site_shortname),
 				urlencode($this->getUUID()),
 				$referrer,
 				$conversions

--- a/Site/SiteWhiteChipmunkModule.php
+++ b/Site/SiteWhiteChipmunkModule.php
@@ -17,6 +17,26 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 	protected $conversions = array();
 
 	// }}}
+	// {{{ public function depends()
+
+	/**
+	 * Gets the module features this module depends on
+	 *
+	 * The site account session module depends on the SiteDatabaseModule
+	 * feature.
+	 *
+	 * @return array an array of {@link SiteApplicationModuleDependency}
+	 *                        objects defining the features this module
+	 *                        depends on.
+	 */
+	public function depends()
+	{
+		$depends = parent::depends();
+		$depends[] = new SiteApplicationModuleDependency('SiteConfigModule');
+		return $depends;
+	}
+
+	// }}}
 	// {{{ public function init()
 
 	public function init()

--- a/Site/SiteWhiteChipmunkModule.php
+++ b/Site/SiteWhiteChipmunkModule.php
@@ -103,12 +103,11 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 	 * @param string $name the name of the cookie to set.
 	 * @param mixed $value the value of the cookie.
 	 * @param mixed $expiry the expiry date as a UNIX timestamp or a
-	                         string parsable by strtotime().
+	 *                       string parsable by strtotime().
 	 * @param string $path the URL path this cookie is valid for.
-	 * @param string $domain the domain this cookie is valid for.
 	 */
 	protected function setCookie($name, $value, $expiry = null,
-		$path = '/', $domain = null)
+		$path = '/')
 	{
 		if ($expiry === null) {
 			$expiry = strtotime('+90 days');
@@ -132,9 +131,8 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 	 *
 	 * @param string $name the name of the cookie to set.
 	 * @param string $path the URL path this cookie is valid for.
-	 * @param string $domain the domain this cookie is valid for.
 	 */
-	protected function removeCookie($name, $path = '/', $domain = null)
+	protected function removeCookie($name, $path = '/')
 	{
 		// Set expiry time to the past. The expiry of 25 hours in the past is
 		// used because time() uses the server's local time and some browsers
@@ -147,12 +145,7 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 		// unsetting cookies.
 		$value = 0;
 
-		// TODO: get from application when on a multi-instance site.
-		//if ($domain = null)
-		//	$domain =
-
 		setcookie($name, $value, $expiry, $path);
-		//setcookie($name, $value, $expiry, $path, $domain);
 
 		unset($_COOKIE[$name]);
 	}

--- a/Site/SiteWhiteChipmunkModule.php
+++ b/Site/SiteWhiteChipmunkModule.php
@@ -170,8 +170,9 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 	 */
 	public function __get($name)
 	{
-		if (!isset($_COOKIE[$name]))
+		if (!isset($_COOKIE[$name])) {
 			throw new SiteCookieException("Cookie '{$name}' is not set.");
+		}
 
 		try {
 			$value = SwatString::signedUnserialize(

--- a/Site/SiteWhiteChipmunkModule.php
+++ b/Site/SiteWhiteChipmunkModule.php
@@ -14,6 +14,7 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 
 	protected $enabled = true;
 	protected $cookie_name;
+	protected $conversions = array();
 
 	// }}}
 	// {{{ public function init()
@@ -25,6 +26,17 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 		$this->cookie_name = sprintf(
 			'%s_chipmunk_uuid',
 			$config->white_chipmunk->shortname
+		);
+	}
+
+	// }}}
+	// {{{ public function addConversion()
+
+	public function addConversion($sku, $value)
+	{
+		$this->conversions = array(
+			$sku,
+			$value
 		);
 	}
 
@@ -41,13 +53,26 @@ class SiteWhiteChipmunkModule extends SiteApplicationModule
 				)
 				: '';
 
+			$conversions = '';
+			$count = 0;
+			foreach ($this->conversions as $conversion) {
+				$conversions.= sprintf(
+					'&sku%1$s=%2$s&conversionvalue%1$s=%3$s',
+					$count,
+					urlencode($this->sku),
+					urlencode($this->conversion_value)
+				);
+				$count++;
+			}
+
 			printf(
 				'<div style="display: none;">'.
 				'<img height="1" width="1" border="0" '.
-				'src="https://www.whitechipmunk.com/%s?uid=%s%s" /></div>',
+				'src="https://www.whitechipmunk.com/%s?uid=%s%s%s" /></div>',
 				urlencode($this->app->config->white_chipmunk->shortname),
 				urlencode($this->getUUID()),
-				$referrer
+				$referrer,
+				$conversions
 			);
 		}
 	}

--- a/Site/SiteWhiteChipmunkModule.php
+++ b/Site/SiteWhiteChipmunkModule.php
@@ -1,0 +1,200 @@
+<?php
+
+require_once 'Site/SiteApplicationModule.php';
+
+/**
+ * Module for dislaying WhiteChimpmunk tracking pixels.
+ *
+ * @package   Site
+ * @copyright 2016 silverorange
+ */
+class SiteWhiteChipmunkModule extends SiteApplicationModule
+{
+	// {{{ protected properties
+
+	protected $enabled = true;
+	protected $cookie_name;
+
+	// }}}
+	// {{{ public function init()
+
+	public function init()
+	{
+		$config = $this->app->getModule('SiteConfigModule');
+		$this->enabled = $config->white_chipmunk->enabled;
+		$this->cookie_name = sprintf(
+			'%s_chipmunk_uuid',
+			$config->white_chipmunk->shortname
+		);
+	}
+
+	// }}}
+	// {{{ public function displayPixel()
+
+	public function displayPixel()
+	{
+		if ($this->enabled) {
+			$referrer = (isset($_SERVER['HTTP_REFERER']))
+				? sprintf(
+					'&referer=%s',
+					urlencode($_SERVER['HTTP_REFERER'])
+				)
+				: '';
+
+			printf(
+				'<div style="display: none;">'.
+				'<img height="1" width="1" border="0" '.
+				'src="https://www.whitechipmunk.com/%s?uid=%s%s" /></div>',
+				urlencode($this->app->config->white_chipmunk->shortname),
+				urlencode($this->getUUID()),
+				$referrer
+			);
+		}
+	}
+
+	// }}}
+	// {{{ protected function getUUID()
+
+	protected function getUUID()
+	{
+		$uuid = (isset($this->{$this->cookie_name}))
+			? $this->{$this->cookie_name}
+			: uniqid();
+
+		$this->setCookie(
+			$this->cookie_name,
+			$uuid
+		);
+
+		return $uuid;
+	}
+
+	// }}}
+	// {{{ protected function setCookie()
+
+	/**
+	 * Sets a cookie
+	 *
+	 * @param string $name the name of the cookie to set.
+	 * @param mixed $value the value of the cookie.
+	 * @param mixed $expiry the expiry date as a UNIX timestamp or a
+	                         string parsable by strtotime().
+	 * @param string $path the URL path this cookie is valid for.
+	 * @param string $domain the domain this cookie is valid for.
+	 */
+	protected function setCookie($name, $value, $expiry = null,
+		$path = '/', $domain = null)
+	{
+		if ($expiry === null) {
+			$expiry = strtotime('+90 days');
+		} elseif (is_string($expiry)) {
+			$expiry = strtotime($expiry);
+		}
+
+		$cookie_value = SwatString::signedSerialize(
+			$value,
+			$this->getSalt()
+		);
+
+		setcookie($name, $cookie_value, $expiry, $path);
+	}
+
+	// }}}
+	// {{{ protected function removeCookie()
+
+	/**
+	 * Remove a cookie
+	 *
+	 * @param string $name the name of the cookie to set.
+	 * @param string $path the URL path this cookie is valid for.
+	 * @param string $domain the domain this cookie is valid for.
+	 */
+	protected function removeCookie($name, $path = '/', $domain = null)
+	{
+		// Set expiry time to the past. The expiry of 25 hours in the past is
+		// used because time() uses the server's local time and some browsers
+		// use local time rather than UTC to trigger cookie deletion. 25 hours
+		// takes into account all time-zone differences.
+		$expiry = time() - 3600 * 25;
+
+		// Some browsers set the cookie value to 'deleted' when an empty string
+		// is used as a cookie value. The value '0' is chosen instead for
+		// unsetting cookies.
+		$value = 0;
+
+		// TODO: get from application when on a multi-instance site.
+		//if ($domain = null)
+		//	$domain =
+
+		setcookie($name, $value, $expiry, $path);
+		//setcookie($name, $value, $expiry, $path, $domain);
+
+		unset($_COOKIE[$name]);
+	}
+
+	// }}}
+	// {{{ public function __get()
+
+	/**
+	 * Gets a cookie value
+	 *
+	 * @param string $name the name of the cookie to get.
+	 *
+	 * @return mixed the value of the cookie. If there is an error
+	 *               unserializing the cookie value, null is returned.
+	 */
+	public function __get($name)
+	{
+		if (!isset($_COOKIE[$name]))
+			throw new SiteCookieException("Cookie '{$name}' is not set.");
+
+		try {
+			$value = SwatString::signedUnserialize(
+				$_COOKIE[$name],
+				$this->getSalt()
+			);
+		} catch (SwatInvalidSerializedDataException $e) {
+
+			// Ignore common cookie values used to remove cookies.
+			$ignored_values = array(0, '');
+
+			if (!in_array($_COOKIE[$name], $ignored_values)) {
+				// If the cookie can't be unserialized, then log it and
+				// continue execution.
+				$e = new SiteCookieException($e);
+				$e->process(false);
+			}
+
+			// Remove the cookie to prevent further exceptions.
+			$value = null;
+			$this->removeCookie($name);
+		}
+
+		return $value;
+	}
+
+	// }}}
+	// {{{ public function __isset()
+
+	/**
+	 * Checks the existence of a cookie
+	 *
+	 * @param string $name the name of the cookie to check.
+	 */
+	public function __isset($name)
+	{
+		return isset($_COOKIE[$name]);
+	}
+
+	// }}}
+	// {{{ public function getSalt()
+
+	protected function getSalt()
+	{
+		return $this->app->config->white_chipmunk->salt;
+	}
+
+	// }}}
+}
+
+?>


### PR DESCRIPTION
White Chipmunk is a custom tracker being used by a subcontractor for one
of our clients.

This code is not perfect, but a very quick and dirty implementation for
a short run experiment that can be cleaned up if it needs to live for
very long.

Note that it does it's own cookie writing and reading - this is because
SiteCookieModule prefixes cookie names with the site's shortname, and we
don't want this behaviour for this tracker, so that multiple sites that
live in the same domain can read and write the same cookie. If this
lives for long enough, the prefixing of the cookie should be added to
SiteCookieModule as an option that can be turned off instead of
duplicating code here.