### PR TITLE
Rely on autoloading for PEAR::XML_RPC2.

### DIFF
--- a/Site/pages/SiteXMLRPCServer.php
+++ b/Site/pages/SiteXMLRPCServer.php
@@ -2,7 +2,6 @@
 
 require_once 'Site/pages/SitePage.php';
 require_once 'Site/layouts/SiteXMLRPCServerLayout.php';
-require_once 'XML/RPC2/Server.php';
 
 /**
  * Base class for an XML-RPC Server


### PR DESCRIPTION
https://trello.com/c/hRpm32LH/1291-fix-xml-rpc2-require-once-call-for-composer-sites

This package does not add itself to the include path so require once fails on composer sites.