### PR TITLE
Move mandrill template prefix setting to Site

### DIFF
--- a/Site/Site.php
+++ b/Site/Site.php
@@ -381,6 +381,7 @@ class Site
 
 			// Mandrill
 			'mandrill.api_key' => null,
+			'mandrill.template_prefix' => null,
 		);
 	}
 


### PR DESCRIPTION
It can be useful if multiple sites share the same Mandrill/MailChimp account. It lets you have a template like `forgot-password` with prefixes like `site1-forgot-password`, `site2-forgot-password`, etc.