### PR TITLE
Consistify names and make signon more extendable

### DIFF
--- a/Site/dataobjects/SiteApiCredential.php
+++ b/Site/dataobjects/SiteApiCredential.php
@@ -47,7 +47,7 @@ class SiteApiCredential extends SwatDBDataObject
 	// }}}
 	// {{{ public function loadByApiKey()
 
-	public function loadByApiKey($key)
+	public function loadByApiKey($key, SiteInstance $instance =  null)
 	{
 		$this->checkDB();
 
@@ -57,7 +57,16 @@ class SiteApiCredential extends SwatDBDataObject
 			$sql = sprintf(
 				'select * from %s where api_key = %s',
 				$this->table,
-				$this->db->quote($key, 'text'));
+				$this->db->quote($key, 'text')
+			);
+
+			if ($instance instanceof SiteInstance) {
+				$sql = sprintf(
+					'%s and instance = %s',
+					$sql,
+					$this->db->quote($instance->id, 'integer')
+				);
+			}
 
 			$rs = SwatDB::query($this->db, $sql, null);
 			$row = $rs->fetchRow(MDB2_FETCHMODE_ASSOC);
@@ -80,6 +89,11 @@ class SiteApiCredential extends SwatDBDataObject
 		$this->table = 'ApiCredential';
 		$this->id_field = 'integer:id';
 		$this->registerDateProperty('createdate');
+
+		$this->registerInternalProperty(
+			'instance',
+			SwatDBClassMap::get('SiteInstance')
+		);
 	}
 
 	// }}}

--- a/Site/dataobjects/SiteApiSignOnToken.php
+++ b/Site/dataobjects/SiteApiSignOnToken.php
@@ -4,13 +4,13 @@ require_once 'SwatDB/SwatDBDataObject.php';
 require_once 'Site/dataobjects/SiteApiCredential.php';
 
 /**
- * A one-time use sign-on token
+ * A one-time use token used to sign on using the API
  *
  * @package   Site
  * @copyright 2013-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
-class SiteSignOnToken extends SwatDBDataObject
+class SiteApiSignOnToken extends SwatDBDataObject
 {
 	// {{{ public properties
 
@@ -43,11 +43,13 @@ class SiteSignOnToken extends SwatDBDataObject
 	{
 		parent::init();
 
-		$this->table = 'SignOnToken';
+		$this->table = 'ApiSignOnToken';
 		$this->id_field = 'integer:id';
 
-		$this->registerInternalProperty('api_credential',
-			SwatDBClassMap::get('SiteApiCredential'));
+		$this->registerInternalProperty(
+			'api_credential',
+			SwatDBClassMap::get('SiteApiCredential')
+		);
 
 		$this->registerDateProperty('createdate');
 	}

--- a/Site/exceptions/SiteApiSignOnException.php
+++ b/Site/exceptions/SiteApiSignOnException.php
@@ -3,13 +3,13 @@
 require_once 'Swat/exceptions/SwatException.php';
 
 /**
- * Generic exception to be used during the single sign on process
+ * Generic exception to be used during the API sign on process
  *
  * @package   Site
  * @copyright 2013-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
-class SiteSingleSignOnException extends SwatException
+class SiteApiSignOnException extends SwatException
 {
 }
 

--- a/Site/pages/SiteApiGetTokenPage.php
+++ b/Site/pages/SiteApiGetTokenPage.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once 'Site/pages/SitePage.php';
-require_once 'Site/dataobjects/SiteSignOnToken.php';
+require_once 'Site/dataobjects/SiteApiSignOnToken.php';
 require_once 'Site/dataobjects/SiteApiCredential.php';
 
 /**
@@ -32,7 +32,8 @@ class SiteApiGetTokenPage extends SitePage
 
 		$response = $this->getJsonResponse(
 			$this->getIdent(),
-			$this->getVar('key'));
+			$this->getVar('key')
+		);
 
 		$this->layout->startCapture('content');
 		echo json_encode($response);
@@ -44,8 +45,11 @@ class SiteApiGetTokenPage extends SitePage
 
 	protected function getVar($name)
 	{
-		return SiteApplication::initVar($name, null,
-			SiteApplication::VAR_GET);
+		return SiteApplication::initVar(
+			$name,
+			null,
+			SiteApplication::VAR_GET
+		);
 	}
 
 	// }}}
@@ -62,10 +66,10 @@ class SiteApiGetTokenPage extends SitePage
 	protected function getJsonResponse($ident, $key)
 	{
 		$class_name = SwatDBClassMap::get('SiteApiCredential');
-		$credentials = new $class_name();
-		$credentials->setDatabase($this->app->db);
+		$credential = new $class_name();
+		$credential->setDatabase($this->app->db);
 
-		if (!$credentials->loadByApiKey($key)) {
+		if (!$credential->loadByApiKey($key)) {
 			return array(
 				'status' => array(
 					'code'    => 'error',
@@ -83,26 +87,26 @@ class SiteApiGetTokenPage extends SitePage
 			);
 		}
 
-		$response = $this->getSignOnToken($ident, $credentials);
+		$response = $this->getSignOnToken($ident, $credential);
 		return $response;
 	}
 
 	// }}}
 	// {{{ protected function getSignOnToken()
 
-	protected function getSignOnToken($ident, SiteApiCredential $credentials)
+	protected function getSignOnToken($ident, SiteApiCredential $credential)
 	{
-		$class_name = SwatDBClassMap::get('SiteSignOnToken');
-		$sign_on_token = new $class_name();
-		$sign_on_token->setDatabase($this->app->db);
+		$class_name = SwatDBClassMap::get('SiteApiSignOnToken');
+		$token = new $class_name();
+		$token->setDatabase($this->app->db);
 
-		if (!$sign_on_token->loadByIdent($ident, $credentials)) {
-			$sign_on_token->ident = $ident;
-			$sign_on_token->api_credential = $credentials->id;
-			$sign_on_token->token = uniqid();
-			$sign_on_token->createdate = new SwatDate();
-			$sign_on_token->createdate->toUTC();
-			$sign_on_token->save();
+		if (!$token->loadByIdent($ident, $credential)) {
+			$token->ident = $ident;
+			$token->api_credential = $credential->id;
+			$token->token = uniqid();
+			$token->createdate = new SwatDate();
+			$token->createdate->toUTC();
+			$token->save();
 		}
 
 		return array(
@@ -110,7 +114,7 @@ class SiteApiGetTokenPage extends SitePage
 				'code'    => 'ok',
 				'message' => '',
 			),
-			'token'  => $sign_on_token->token,
+			'token'  => $token->token,
 		);
 	}
 

--- a/Site/pages/SiteSharedSecretAuthPage.php
+++ b/Site/pages/SiteSharedSecretAuthPage.php
@@ -33,10 +33,15 @@ class SiteSharedSecretAuthPage extends SitePageDecorator
 			$expected = $this->getHashMac($message, $key);
 			$provided = (isset($_GET['mac'])) ? $_GET['mac'] : '';
 
-			throw new SiteInvalidMacException(sprintf(
-				"Invalid message authentication code.\n\n".
-				"Code expected: %s.\n".
-				"Code provided: %s.", $expected, $provided));
+			throw new SiteInvalidMacException(
+				sprintf(
+					"Invalid message authentication code.\n\n".
+					"Code expected: %s.\n".
+					"Code provided: %s.",
+					$expected,
+					$provided
+				)
+			);
 		}
 
 		parent::init();
@@ -54,15 +59,19 @@ class SiteSharedSecretAuthPage extends SitePageDecorator
 		}
 
 		$class_name = SwatDBClassMap::get('SiteApiCredential');
-		$credentials = new $class_name();
-		$credentials->setDatabase($this->app->db);
+		$credential = new $class_name();
+		$credential->setDatabase($this->app->db);
 
-		if (!$credentials->loadByApiKey($api_key)) {
-			throw new SiteInvalidMacException(sprintf(
-				'Unable to load shared secret for API key: %s.', $api_key));
+		if (!$credential->loadByApiKey($api_key)) {
+			throw new SiteInvalidMacException(
+				sprintf(
+					'Unable to load shared secret for API key: %s.',
+					$api_key
+				)
+			);
 		}
 
-		return $credentials->api_shared_secret;
+		return $credential->api_shared_secret;
 	}
 
 	// }}}
@@ -94,20 +103,6 @@ class SiteSharedSecretAuthPage extends SitePageDecorator
 
 		return ((isset($_GET['mac'])) &&
 			($this->getHashMac($message, $key) === $_GET['mac']));
-	}
-
-	// }}}
-	// {{{ protected function getApiKey()
-
-	protected function getApiKey()
-	{
-		$api_key = (isset($_GET['key'])) ? $_GET['key'] : '';
-
-		if ($api_key == '') {
-			throw new SiteInvalidMacException('No API key provided.');
-		}
-
-		return $api_key;
 	}
 
 	// }}}

--- a/sql/pgsql/tables/ApiCredential.sql
+++ b/sql/pgsql/tables/ApiCredential.sql
@@ -1,14 +1,15 @@
 create table ApiCredential (
 	id serial,
 	title             varchar(255) not null,
-	api_key           varchar(255) unique,
+	api_key           varchar(255),
 	api_shared_secret varchar(255),
 	createdate        timestamp not null,
-	primary key (id)
+
+	instance integer references Instance(id) on delete set null,
+
+	primary key (id),
+	unique (api_key, instance)
 );
 
-create index ApiCredential_api_key on ApiCredential(api_key);
-
--- TEMP
-alter table Account add api_credential integer references ApiCredential(id);
-CREATE INDEX Account_api_credential_index ON Account(api_credential);
+create index ApiCredential_api_key_index on ApiCredential(api_key);
+create index ApiCredential_instance_index on ApiCredential(instance);

--- a/sql/pgsql/tables/ApiSignOnToken.sql
+++ b/sql/pgsql/tables/ApiSignOnToken.sql
@@ -1,4 +1,4 @@
-create table SignOnToken (
+create table ApiSignOnToken (
 	id serial,
 
 	ident varchar(255) not null,
@@ -9,3 +9,6 @@ create table SignOnToken (
 
 	primary key (id)
 );
+
+create index ApiSignOnToken_ident_index on ApiSignOnToken(ident);
+create index ApiSignOnToken_token_index on ApiSignOnToken(token);


### PR DESCRIPTION
SQL changes needed to be run once this package is sync live:
```sql
alter table SignOnToken rename to ApiSignOnToken;

create index ApiSignOnToken_ident_index on ApiSignOnToken(ident);
create index ApiSignOnToken_token_index on ApiSignOnToken(token);

alter table ApiCredential add column instance integer references Instance(id) on delete set null;
create index ApiCredential_instance_index on ApiCredential(instance);
-- Drop old unique constraint
alter table ApiCredential drop constraint apicredential_api_key_key;
alter table ApiCredential add constraint apicredential_api_key_instance_key unique(api_key, instance);
```