### PR TITLE
Use composer autoloader to load Psr\Log interfaces.

### DIFF
--- a/Site/SiteAMQPApplication.php
+++ b/Site/SiteAMQPApplication.php
@@ -2,7 +2,6 @@
 
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
-require_once 'Psr/Log/LoggerInterface.php';
 require_once 'Console/CommandLine.php';
 require_once 'Site/Site.php';
 require_once 'Site/SiteApplication.php';

--- a/Site/SiteCommandLineLogger.php
+++ b/Site/SiteCommandLineLogger.php
@@ -3,8 +3,6 @@
 /* vim: set noexpandtab tabstop=4 shiftwidth=4 foldmethod=marker: */
 
 require_once 'Console/CommandLine.php';
-require_once 'Psr/Log/LogLevel.php';
-require_once 'Psr/Log/LoggerInterface.php';
 
 /**
  * PSR-3 compliant logger that sends messages to STDOUT and STDERR through


### PR DESCRIPTION
This pacakge does not have include path compatibility mode and must use an autoloader.

https://trello.com/c/HFhP4Akw/1542-fix-broken-require-once-for-psr-log-in-amqp-workers