### PR TITLE
Fix incorrect variable name in exception message for CDN distribution key

### DIFF
--- a/Site/SiteAmazonCdnModule.php
+++ b/Site/SiteAmazonCdnModule.php
@@ -137,7 +137,7 @@ class SiteAmazonCdnModule extends SiteCdnModule
 			throw new SiteCdnException(
 				sprintf(
 					'Distribution Private Key ‘%s’ missing.',
-					$file
+					$distribution_private_key_file
 				)
 			);
 		}


### PR DESCRIPTION
https://trello.com/c/wHhzcRkG/1582-fix-variable-name-in-exception-message-for-cdn-distribution-key