### PR TITLE
Set the superglobal $_COOKIE when starting the session.

### DIFF
--- a/Site/SiteSessionModule.php
+++ b/Site/SiteSessionModule.php
@@ -610,7 +610,15 @@ class SiteSessionModule extends SiteApplicationModule
 		// Explicitly set the session cookie since PHP doesn't do this
 		// sometimes on SSL requests.
 		if (ini_get('session.use_cookies') == 1) {
-			setcookie(session_name(), session_id(), 0, '/');
+			$cookie_name = session_name();
+			$cookie_value = session_id();
+
+			setcookie($cookie_name, $cookie_value, 0, '/');
+
+			// Also explicitly set $_COOKIE since its value is only accessible
+			// on subsequent page loads and we may need the value during the
+			// remainder of the current request.
+			$_COOKIE[$cookie_name] = $cookie_value;
 		}
 
 		$this->restoreRegisteredObjectDBConnections();


### PR DESCRIPTION
The $_COOKIE value may be checked during the remainder of the request to see if the session is active.

This fixes the first page redirect on sign-in including the session identifier as a HTTP GET parameter.

Testing
--------
 1. Check out CourseHost. Make sure https://github.com/silverorange/course-host/pull/760 is merged.
 2. update composer.json to point to this `silverorange/site` package branch
 3. run composer update
 4. On hamlin, sign in and sign out of course-host
 5. With branch active no SID will be appended to the URL. With master active, SID will be appended.