### PR TITLE
Increase the max filesize for media

### DIFF
--- a/sql/pgsql/tables/MediaEncodingBinding.sql
+++ b/sql/pgsql/tables/MediaEncodingBinding.sql
@@ -3,7 +3,7 @@ create table MediaEncodingBinding (
 	media_encoding integer not null references MediaEncoding(id),
 	media_type     integer not null references MediaType(id),
 
-	filesize integer,
+	filesize bigint,
 
 	on_cdn boolean not null default false,
 


### PR DESCRIPTION
Currently we top out at 2.14 GB.

The following SQL can be used to convert:

```
begin;
alter table mediaencodingbinding add filesize_big bigint;
update mediaencodingbinding set filesize_big = filesize;
alter table mediaencodingbinding rename filesize to filesize_old;
alter table mediaencodingbinding rename filesize_big to filesize;
alter table mediaencodingbinding drop filesize_old;
commit;
```

I've already updated EM:RAP live.
