### PR TITLE
Disable button after sending password reset

### DIFF
--- a/Site/admin/components/Account/ForgotPassword.php
+++ b/Site/admin/components/Account/ForgotPassword.php
@@ -106,7 +106,6 @@ class SiteAccountForgotPassword extends AdminConfirmation
 
 		$form = $this->ui->getWidget('confirmation_form');
 		$form->addHiddenField('id', $this->id);
-
 		$this->title = $this->account->getFullname();
 
 		$this->navbar->createEntry(
@@ -125,8 +124,14 @@ class SiteAccountForgotPassword extends AdminConfirmation
 		$message->content = $this->getConfirmationMessage();
 		$message->content_type = 'text/xml';
 
-		$this->ui->getWidget('yes_button')->title =
-			Site::_('Send Forgot Password Reset Email');
+		$yes_button = $this->ui->getWidget('yes_button');
+		$yes_button->title = Site::_('Send Forgot Password Reset Email');
+		$yes_button->show_processing_throbber = true;
+
+		$form->addStyleSheet(
+			'packages/site/styles/site-admin-forgot-password-page.css'
+		);
+
 	}
 
 	// }}}

--- a/www/styles/site-admin-forgot-password-page.css
+++ b/www/styles/site-admin-forgot-password-page.css
@@ -1,0 +1,3 @@
+.swat-footer-form-field .swat-button-processing-throbber {
+    display: none;
+}


### PR DESCRIPTION
This patch disables the submit button on the Account > Forgot Password dialog after pressing it. This prevents admins from accidentally submitting the form multiple times and sending multiple resets. 

I hid the spinner graphic because it looks ugly where it is by default (in between confirm/cancel buttons), looks out of context sitting to the right of both buttons, and makes the pre-submitted form look weird sitting to the left (blank space). ¯\_(ツ)_/¯