### PR TITLE
Add a global on/off flag for analytics

### DIFF
--- a/Site/Site.php
+++ b/Site/Site.php
@@ -235,6 +235,7 @@ class Site
 
 			// Analytics
 			// Google analytics website property id (UA-XXXXX-XXX)
+			'analytics.enabled'                          => true,
 			'analytics.google_account'                   => null,
 
 			// Google analytics account id (XXXXXXXX)

--- a/Site/SiteAnalyticsModule.php
+++ b/Site/SiteAnalyticsModule.php
@@ -40,6 +40,13 @@ class SiteAnalyticsModule extends SiteApplicationModule
 	protected $google_account;
 
 	/**
+	 * Flag to tell whether analytics are enabled on this site.
+	 *
+	 * @var boolean
+	 */
+	protected $analytics_enabled = true;
+
+	/**
 	 * Flag to tell whether the user has opted out of analytics.
 	 *
 	 * @var boolean
@@ -179,12 +186,10 @@ class SiteAnalyticsModule extends SiteApplicationModule
 			$config->analytics->friendbuy_account_id;
 
 		if (!$config->analytics->enabled) {
-			// We don't want to have any analytics on this site
-			// So we'll treat everyone as an opt-out
-			$this->analytics_opt_out = true;
-		} else {
-			$this->initOptOut();
+			$this->analytics_enabled = false;
 		}
+
+		$this->initOptOut();
 
 		// skip init of the commands if we're opted out.
 		if (!$this->analytics_opt_out) {
@@ -310,7 +315,8 @@ class SiteAnalyticsModule extends SiteApplicationModule
 	{
 		return (
 			$this->google_account != '' &&
-			!$this->analytics_opt_out
+			!$this->analytics_opt_out &&
+			$this->analytics_enabled
 		);
 	}
 
@@ -504,7 +510,8 @@ JS;
 	{
 		return (
 			$this->facebook_pixel_id != '' &&
-			!$this->analytics_opt_out
+			!$this->analytics_opt_out &&
+			$this->analytics_enabled
 		);
 	}
 
@@ -660,7 +667,8 @@ JS;
 	{
 		return (
 			$this->twitter_track_pixel_id != '' &&
-			!$this->analytics_opt_out
+			!$this->analytics_opt_out &&
+			$this->analytics_enabled
 		);
 	}
 
@@ -806,7 +814,8 @@ JS;
 	{
 		return (
 			$this->bing_uet_id != '' &&
-			!$this->analytics_opt_out
+			!$this->analytics_opt_out &&
+			$this->analytics_enabled
 		);
 	}
 
@@ -956,7 +965,8 @@ JS;
 		return (
 			$this->pardot_account_id != '' &&
 			$this->pardot_campaign_id != '' &&
-			!$this->analytics_opt_out
+			!$this->analytics_opt_out &&
+			$this->analytics_enabled
 		);
 	}
 

--- a/Site/SiteAnalyticsModule.php
+++ b/Site/SiteAnalyticsModule.php
@@ -178,7 +178,13 @@ class SiteAnalyticsModule extends SiteApplicationModule
 		$this->friendbuy_account_id =
 			$config->analytics->friendbuy_account_id;
 
-		$this->initOptOut();
+		if (!$config->analytics->enabled) {
+			// We don't want to have any analytics on this site
+			// So we'll treat everyone as an opt-out
+			$this->analytics_opt_out = true;
+		} else {
+			$this->initOptOut();
+		}
 
 		// skip init of the commands if we're opted out.
 		if (!$this->analytics_opt_out) {


### PR DESCRIPTION
The analytics modules already respect the analytics_opt_out flag, so if we enable this flag for every user on development/staging, this should prevent test data from leaking into the live analytics. This patch sets the analytics_opt_out flag to true for all users if analytics.enabled is set to "Off" in the ini. 

The 'enabled' flag defaults to true, so this should be a nonbreaking change (sites without an explicit setting will continue to operate as they have been). 