### PR TITLE
Properly delete the media from the CDN

### DIFF
--- a/Site/SiteAmazonCdnModule.php
+++ b/Site/SiteAmazonCdnModule.php
@@ -335,12 +335,7 @@ class SiteAmazonCdnModule extends SiteCdnModule
 	public function removeFile($filename)
 	{
 		try {
-			$this->s3->deleteObject(
-				array(
-					'Bucket' => $this->bucket,
-					'Key'    => $filename,
-				)
-			);
+			$this->s3->deleteMatchingObjects($this->bucket, $filename);
 		} catch (Aws\Exception\AwsException $e) {
 			throw new SiteCdnException($e);
 		}

--- a/Site/dataobjects/SiteVideoMedia.php
+++ b/Site/dataobjects/SiteVideoMedia.php
@@ -457,7 +457,6 @@ class SiteVideoMedia extends SiteMedia
 				$this->path_key,
 			);
 
-
 			$class_name = SwatDBClassMap::get('SiteMediaCdnTask');
 			$task = new $class_name();
 			$task->setDatabase($this->db);

--- a/Site/dataobjects/SiteVideoMedia.php
+++ b/Site/dataobjects/SiteVideoMedia.php
@@ -447,6 +447,27 @@ class SiteVideoMedia extends SiteMedia
 	}
 
 	// }}}
+	// {{{ protected function deleteCdnFiles()
+
+	protected function deleteCdnFiles()
+	{
+		if ($this->getUriBase() != '') {
+			$path = array(
+				$this->getUriBase(),
+				$this->path_key,
+			);
+
+
+			$class_name = SwatDBClassMap::get('SiteMediaCdnTask');
+			$task = new $class_name();
+			$task->setDatabase($this->db);
+			$task->operation = 'delete';
+			$task->file_path = implode(DIRECTORY_SEPARATOR, $path);
+			$task->save();
+		}
+	}
+
+	// }}}
 }
 
 ?>


### PR DESCRIPTION
This queues up media for deleting properly. It also updates the S3 module to delete all objects matching a prefix. I've tested this with both `media/test.zip` and `media/test/{a whole directory of content and sub-dirs}` and it works in both cases.