### PR TITLE
The logger configure already happens in app

### DIFF
--- a/Site/SiteCommandLineConfigModule.php
+++ b/Site/SiteCommandLineConfigModule.php
@@ -31,14 +31,6 @@ class SiteCommandLineConfigModule extends SiteConfigModule
 	{
 		parent::configure();
 
-		if (isset($this->exceptions->log_location))
-			SwatException::setLogger(new SiteExceptionLogger(
-				$this->exceptions->log_location, $this->exceptions->base_uri));
-
-		if (isset($this->errors->log_location))
-			SwatError::setLogger(new SiteErrorLogger(
-				$this->errors->log_location, $this->errors->base_uri));
-
 		$this->app->database->dsn = $this->database->dsn;
 
 		if ($this->date->time_zone !== null) {


### PR DESCRIPTION
This overwrites any loggers that may have already been setup which we
don't want. These loggers are already setup in Application so this code
is redundant and destructive.

You can see this is already handled here: https://github.com/silverorange/site/blob/master/Site/SiteApplication.php#L414