### PR TITLE
No application level tls

### DIFF
--- a/Site/Site.php
+++ b/Site/Site.php
@@ -217,10 +217,8 @@ class Site
 
 			// URIs
 			'uri.base'                 => null,
-			'uri.secure_base'          => null,
 			'uri.absolute_base'        => null,
 			'uri.cdn_base'             => null,
-			'uri.secure_cdn_base'      => null,
 			'uri.admin_base'           => null,
 			'uri.account_login'        => 'account/login',
 

--- a/Site/Site.php
+++ b/Site/Site.php
@@ -313,7 +313,7 @@ class Site
 			'comment.akismet_key'      => null,
 
 			// amazon AWS
-			// @see http://docs.aws.amazon.com/general/latest/gr/rande.html
+			// @see https://docs.aws.amazon.com/general/latest/gr/rande.html
 			'amazon.region' => 'us-east-1',
 
 			// amazon S3
@@ -345,7 +345,7 @@ class Site
 			// Expiry dates for the privateer data deleter
 			'expiry.contact_messages' => '1 year',
 
-			// P3P headers. See http://en.wikipedia.org/wiki/P3P
+			// P3P headers. See https://en.wikipedia.org/wiki/P3P
 			'p3p.compact_policy' => null,
 			'p3p.policy_uri'     => null,
 

--- a/Site/SiteAMQPModule.php
+++ b/Site/SiteAMQPModule.php
@@ -99,7 +99,7 @@ class SiteAMQPModule extends SiteApplicationModule
 	 * @param string $exchange   the job exchange name.
 	 * @param string $message    the job data.
 	 * @param array  $attributes optional. Additional message attributes. See
-	 *                           {@link https://secure.php.net/manual/fa/amqpexchange.publish.php}.
+	 *                           {@link https://github.com/pdezwart/php-amqp/blob/master/stubs/AMQPExchange.php#L155}
 	 *
 	 * @return void
 	 */
@@ -139,7 +139,7 @@ class SiteAMQPModule extends SiteApplicationModule
 	 * @param string $exchange   the job exchange name.
 	 * @param string $message    the job data.
 	 * @param array  $attributes optional. Additional message attributes. See
-	 *                           {@link https://secure.php.net/manual/fa/amqpexchange.publish.php}.
+	 *                           {@link https://github.com/pdezwart/php-amqp/blob/master/stubs/AMQPExchange.php#L155}
 	 *
 	 * @return void
 	 */
@@ -166,7 +166,7 @@ class SiteAMQPModule extends SiteApplicationModule
 	 * @param string $exchange   the job exchange name.
 	 * @param string $message    the job data.
 	 * @param array  $attributes optional. Additional message attributes. See
-	 *                           {@link https://secure.php.net/manual/fa/amqpexchange.publish.php}.
+	 *                           {@link https://github.com/pdezwart/php-amqp/blob/master/stubs/AMQPExchange.php#L155}
 	 *
 	 * @return array an array containing the following fields:
 	 *               - <kbd>status</kbd>   - a string containing "success" for
@@ -313,7 +313,7 @@ class SiteAMQPModule extends SiteApplicationModule
 	 * @param string $exchange   the job exchange name.
 	 * @param string $message    the job data.
 	 * @param array  $attributes optional. Additional message attributes. See
-	 *                           {@link https://secure.php.net/manual/fa/amqpexchange.publish.php}.
+	 *                           {@link https://github.com/pdezwart/php-amqp/blob/master/stubs/AMQPExchange.php#L155}
 	 *
 	 * @return array an array containing the following fields:
 	 *               - <kbd>status</kbd>   - a string containing "success" for

--- a/Site/SiteAMQPModule.php
+++ b/Site/SiteAMQPModule.php
@@ -99,7 +99,7 @@ class SiteAMQPModule extends SiteApplicationModule
 	 * @param string $exchange   the job exchange name.
 	 * @param string $message    the job data.
 	 * @param array  $attributes optional. Additional message attributes. See
-	 *                           {@link http://www.php.net/manual/en/amqpexchange.publish.php}.
+	 *                           {@link https://secure.php.net/manual/fa/amqpexchange.publish.php}.
 	 *
 	 * @return void
 	 */
@@ -139,7 +139,7 @@ class SiteAMQPModule extends SiteApplicationModule
 	 * @param string $exchange   the job exchange name.
 	 * @param string $message    the job data.
 	 * @param array  $attributes optional. Additional message attributes. See
-	 *                           {@link http://www.php.net/manual/en/amqpexchange.publish.php}.
+	 *                           {@link https://secure.php.net/manual/fa/amqpexchange.publish.php}.
 	 *
 	 * @return void
 	 */
@@ -166,7 +166,7 @@ class SiteAMQPModule extends SiteApplicationModule
 	 * @param string $exchange   the job exchange name.
 	 * @param string $message    the job data.
 	 * @param array  $attributes optional. Additional message attributes. See
-	 *                           {@link http://www.php.net/manual/en/amqpexchange.publish.php}.
+	 *                           {@link https://secure.php.net/manual/fa/amqpexchange.publish.php}.
 	 *
 	 * @return array an array containing the following fields:
 	 *               - <kbd>status</kbd>   - a string containing "success" for
@@ -313,7 +313,7 @@ class SiteAMQPModule extends SiteApplicationModule
 	 * @param string $exchange   the job exchange name.
 	 * @param string $message    the job data.
 	 * @param array  $attributes optional. Additional message attributes. See
-	 *                           {@link http://www.php.net/manual/en/amqpexchange.publish.php}.
+	 *                           {@link https://secure.php.net/manual/fa/amqpexchange.publish.php}.
 	 *
 	 * @return array an array containing the following fields:
 	 *               - <kbd>status</kbd>   - a string containing "success" for

--- a/Site/SiteAmazonCdnModule.php
+++ b/Site/SiteAmazonCdnModule.php
@@ -441,7 +441,7 @@ class SiteAmazonCdnModule extends SiteCdnModule
 	protected function getCloudFrontUri(
 		$filename,
 		$expires = null,
-		$streaming = null,
+		$streaming = null
 	) {
 		// 1.x SDK allowed passing strtotime formatted strings for expiration
 		// dates. Modern SDK requires an integer.
@@ -452,7 +452,8 @@ class SiteAmazonCdnModule extends SiteCdnModule
 		$config = $this->app->config->amazon;
 
 		if (!$config->cloudfront_enabled ||
-			!$this->cf instanceof Aws\CloudFront\CloudFrontClient) {
+			!$this->cf instanceof Aws\CloudFront\CloudFrontClient
+		) {
 			throw new SwatException(
 				'CloudFront must be enabled to get CloudFront URIs in the '.
 				'Amazon CDN module'

--- a/Site/SiteAnalyticsModule.php
+++ b/Site/SiteAnalyticsModule.php
@@ -490,13 +490,9 @@ JS;
 	protected function getGoogleAnalyticsTrackingCodeSource()
 	{
 		if ($this->display_advertising) {
-			$source = ($this->app->isSecure())
-				? 'https://stats.g.doubleclick.net/dc.js'
-				: 'http://stats.g.doubleclick.net/dc.js';
+			$source = 'https://stats.g.doubleclick.net/dc.js';
 		} else {
-			$source = ($this->app->isSecure())
-				? 'https://ssl.google-analytics.com/ga.js'
-				: 'http://www.google-analytics.com/ga.js';
+			$source = 'https://ssl.google-analytics.com/ga.js';
 		}
 
 		return $source;

--- a/Site/SiteAnalyticsModule.php
+++ b/Site/SiteAnalyticsModule.php
@@ -9,9 +9,9 @@
  * @package   Site
  * @copyright 2007-2018 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
- * @link      http://code.google.com/apis/analytics/docs/tracking/asyncTracking.html
+ * @link      https://developers.google.com/analytics/devguides/collection/gajs/
  * @link      https://developers.facebook.com/docs/facebook-pixel/api-reference
- * @link      http://help.bingads.microsoft.com/apex/index/3/en-ca/n5012
+ * @link      https://help.bingads.microsoft.com/apex/index/3/en-ca/n5012
  */
 class SiteAnalyticsModule extends SiteApplicationModule
 {

--- a/Site/SiteGravatarEntry.php
+++ b/Site/SiteGravatarEntry.php
@@ -84,7 +84,7 @@ class SiteGravatarEntry extends SwatEmailEntry
 	{
 		$link = new SwatHtmlTag('a');
 		$link->id = $this->id.'_link';
-		$link->href = 'http://www.gravatar.com/';
+		$link->href = 'https://www.gravatar.com/';
 		if ($this->value != '') {
 			$link->href.= md5(trim($this->value));
 		}

--- a/Site/SiteJwPlayerMediaDisplay.php
+++ b/Site/SiteJwPlayerMediaDisplay.php
@@ -517,9 +517,9 @@ class SiteJwPlayerMediaDisplay extends SwatControl
 		}
 
 		return sprintf('Videos on this site require either '.
-			'<a href="http://en.wikipedia.org/wiki/HTML5_video" '.
+			'<a href="https://en.wikipedia.org/wiki/HTML5_video" '.
 			'target="_blank">HTML5 video support</a> (%s %s) or '.
-			'<a href="http://get.adobe.com/flashplayer/" target="_blank">'.
+			'<a href="https://get.adobe.com/flashplayer/" target="_blank">'.
 			'Adobe Flash Player</a> (version 18 or higher). '.
 			'Please upgrade your browser and try again.',
 			SwatString::toList($codecs, 'or'),

--- a/Site/SiteMobileModule.php
+++ b/Site/SiteMobileModule.php
@@ -61,7 +61,7 @@ class SiteMobileModule extends SiteApplicationModule
 	/**
 	 * Get the URL prefix for a mobile URL
 	 *
-	 * By default, 'm', e.g. http://domain.com/m/path.
+	 * By default, 'm', e.g. https://domain.com/m/path.
 	 *
 	 * @return string The prefix for the mobile URL
 	 */

--- a/Site/SiteSessionModule.php
+++ b/Site/SiteSessionModule.php
@@ -389,7 +389,7 @@ class SiteSessionModule extends SiteApplicationModule
 					preg_quote($session_name, '/'));
 
 				$uri = preg_replace($regexp, '', $_SERVER['REQUEST_URI']);
-				$this->app->relocate($uri, null, false);
+				$this->app->relocate($uri, false);
 			}
 		}
 

--- a/Site/SiteWebApplication.php
+++ b/Site/SiteWebApplication.php
@@ -310,7 +310,7 @@ class SiteWebApplication extends SiteApplication
 	protected function getCdnBase()
 	{
 		return $this->config->uri->cdn_base;
-			}
+	}
 
 	// }}}
 	// {{{ protected function configure()
@@ -870,7 +870,6 @@ class SiteWebApplication extends SiteApplication
 			if ($pos !== false) {
 				$base_uri = mb_substr($base_uri, $pos);
 			}
-		}
 		}
 
 		$base_uri_length = mb_strlen($base_uri);

--- a/Site/SiteWebApplication.php
+++ b/Site/SiteWebApplication.php
@@ -802,7 +802,7 @@ class SiteWebApplication extends SiteApplication
 	/**
 	 * Gets the base value for any application admin hrefs
 	 *
-	 * If the config value is set use that, otherwise fall back on the site
+	 * If the admin base config value is set use that, otherwise fall back on the site
 	 * defaults.
 	 *
 	 * @return string the base value for all application admin hrefs.

--- a/Site/SiteWebApplication.php
+++ b/Site/SiteWebApplication.php
@@ -6,7 +6,7 @@
  * Web-applicaitions are set up to resolve pages and handle page requests.
  *
  * @package   Site
- * @copyright 2006-2016 silverorange
+ * @copyright 2006-2018 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SiteWebApplication extends SiteApplication
@@ -19,14 +19,6 @@ class SiteWebApplication extends SiteApplication
 	 * @var string
 	 */
 	protected $base_uri = null;
-
-	/**
-	 * The base value for all of this application's anchor hrefs over secure
-	 * connections
-	 *
-	 * @var string
-	 */
-	protected $secure_base_uri = null;
 
 	/**
 	 * Whether or not this application is loaded over a secure connection
@@ -261,19 +253,24 @@ class SiteWebApplication extends SiteApplication
 	 */
 	protected function parseUri()
 	{
-		$this->secure = (isset($_SERVER['HTTPS']) ||
-			(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
-			$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'));
+		$this->secure = (
+			isset($_SERVER['HTTPS']) || (
+				isset($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
+				$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https'
+			)
+		);
 
 		// check for session module
 		if (isset($this->session) &&
 			$this->session instanceof SiteSessionModule &&
-			$this->session->isActive()) {
-
+			$this->session->isActive()
+		) {
 			// remove session ID from URI since it will be added back where
 			// necessary
-			$regexp = sprintf('/%s=[^&]*&?/u',
-				preg_quote($this->session->getSessionName(), '/'));
+			$regexp = sprintf(
+				'/%s=[^&]*&?/u',
+				preg_quote($this->session->getSessionName(), '/')
+			);
 
 			$this->uri = preg_replace($regexp, '', $_SERVER['REQUEST_URI']);
 		} else {
@@ -292,7 +289,6 @@ class SiteWebApplication extends SiteApplication
 				$regexp = sprintf('|%s|u', $base_uri);
 				if (preg_match($regexp, $this->uri, $matches)) {
 					$this->base_uri = $matches[0];
-					$this->secure_base_uri = $matches[0];
 				}
 			}
 		}
@@ -309,30 +305,12 @@ class SiteWebApplication extends SiteApplication
 	/**
 	 * Gets the base cdn
 	 *
-	 * @param boolean $secure whether or not the base cdn should be a secure
-	 *                         URI. The default value of null maintains the
-	 *                         same security as the current page.
-	 *
 	 * @return string the base cdn or null if cdn settings aren't set.
 	 */
-	protected function getCdnBase($secure = null)
+	protected function getCdnBase()
 	{
-		$cdn_base = null;
-
-		if ($this->config->uri->cdn_base != '' &&
-			$this->config->uri->secure_cdn_base != '') {
-
-			if ($secure === null) {
-				$secure = $this->isSecure();
+		return $this->config->uri->cdn_base;
 			}
-
-			$cdn_base = ($secure === true) ?
-				$this->config->uri->secure_cdn_base :
-				$this->config->uri->cdn_base;
-		}
-
-		return $cdn_base;
-	}
 
 	// }}}
 	// {{{ protected function configure()
@@ -503,7 +481,6 @@ class SiteWebApplication extends SiteApplication
 	public function getReplacementPage($source)
 	{
 		$source = $this->normalizeSource($source);
-		$this->checkSecure($source);
 		$new_page = $this->resolvePage($source);
 
 		return $new_page;
@@ -585,7 +562,6 @@ class SiteWebApplication extends SiteApplication
 	{
 		if ($this->page === null) {
 			$source = $this->normalizeSource(self::initVar('source'));
-			$this->checkSecure($source);
 			$this->page = $this->resolvePage($source);
 		}
 	}
@@ -673,17 +649,6 @@ class SiteWebApplication extends SiteApplication
 	}
 
 	// }}}
-	// {{{ public function setSecureBaseUri()
-
-	/**
-	 * Sets the base URI for secure pages
-	 */
-	public function setSecureBaseUri($uri)
-	{
-		$this->secure_base_uri = $uri;
-	}
-
-	// }}}
 	// {{{ public function relocate()
 
 	/**
@@ -694,11 +659,6 @@ class SiteWebApplication extends SiteApplication
 	 * function to be sure execution does not continue.
 	 *
 	 * @param string $uri the URI to relocate to.
-	 * @param boolean $secure optional. Whether or not the base href should be
-	 *                         a secure URI. The default value of null
-	 *                         maintains the same security as the current page.
-	 *                         This parameter only has an effect if the
-	 *                         <i>$uri</i> is relative.
 	 * @param boolean $append_sid optional. Whether or not to append the
 	 *                             session identifier to the URI. If null or
 	 *                             unspecified, this is determined automatically
@@ -711,7 +671,6 @@ class SiteWebApplication extends SiteApplication
 	 */
 	public function relocate(
 		$uri,
-		$secure = null,
 		$append_sid = null,
 		$permanent = false
 	) {
@@ -720,11 +679,13 @@ class SiteWebApplication extends SiteApplication
 			$this->session instanceof SiteSessionModule)
 				$uri = $this->session->appendSessionId($uri, $append_sid);
 
-		if (mb_substr($uri, 0, 1) != '/' && mb_strpos($uri, '://') === false)
-			$uri = $this->getBaseHref($secure).$uri;
+		if (mb_substr($uri, 0, 1) != '/' && mb_strpos($uri, '://') === false) {
+			$uri = $this->getBaseHref().$uri;
+		}
 
-		if ($permanent)
+		if ($permanent) {
 			header('HTTP/1.1 301 Moved Permanently');
+		}
 
 		header('Location: '.$uri);
 		exit();
@@ -740,11 +701,6 @@ class SiteWebApplication extends SiteApplication
 	 * maintained in automatic redirects.
 	 *
 	 * @param string $uri the URI to relocate to.
-	 * @param boolean $secure optional. Whether or not the base href should be
-	 *                         a secure URI. The default value of null
-	 *                         maintains the same security as the current page.
-	 *                         This parameter only has an effect if the
-	 *                         <i>$uri</i> is relative.
 	 * @param boolean $append_sid optional. Whether or not to append the
 	 *                             session identifier to the URI. If null or
 	 *                             unspecified, this is determined automatically
@@ -757,7 +713,6 @@ class SiteWebApplication extends SiteApplication
 	 */
 	public function relocateWithQueryString(
 		$uri,
-		$secure = null,
 		$append_sid = null,
 		$permanent = false
 	) {
@@ -771,7 +726,7 @@ class SiteWebApplication extends SiteApplication
 			$uri.= $concatenator.$query_string;
 		}
 
-		$this->relocate($uri, $secure, $append_sid, $permanent);
+		$this->relocate($uri, $append_sid, $permanent);
 	}
 
 	// }}}
@@ -785,19 +740,6 @@ class SiteWebApplication extends SiteApplication
 	public function getUri()
 	{
 		return $this->uri;
-	}
-
-	// }}}
-	// {{{ public function isSecure()
-
-	/**
-	 * Whether the current page is being accessed securely
-	 *
-	 * @return boolean whether the current page access is secure.
-	 */
-	public function isSecure()
-	{
-		return $this->secure;
 	}
 
 	// }}}
@@ -837,15 +779,11 @@ class SiteWebApplication extends SiteApplication
 	/**
 	 * Gets the base value for all application anchor hrefs
 	 *
-	 * @param boolean $secure whether or not the base href should be a secure
-	 *                         URI. The default value of null maintains the
-	 *                         same security as the current page.
-	 *
 	 * @return string the base value for all application anchor hrefs.
 	 */
-	public function getBaseHref($secure = null)
+	public function getBaseHref()
 	{
-		$base_href = $this->getRootBaseHref($secure);
+		$base_href = $this->getRootBaseHref();
 
 		if (isset($this->mobile)) {
 			if ($this->mobile->isMobileUrl() &&
@@ -864,27 +802,26 @@ class SiteWebApplication extends SiteApplication
 	/**
 	 * Gets the base value for any application admin hrefs
 	 *
-	 * Admin base value is assumed to always be secure. If the config value is
-	 * set use that, otherwise fall back on the site defaults.
+	 * If the config value is set use that, otherwise fall back on the site
+	 * defaults.
 	 *
 	 * @return string the base value for all application admin hrefs.
 	 */
 	public function getAdminBaseHref()
 	{
 		$admin_base_href = null;
-		$secure = true;
 
 		if ($this->config->uri->admin_base != '') {
 			$admin_base_href = $this->config->uri->admin_base;
 
-			if (mb_substr($admin_base_href, 0, 1) == '/') {
-				$admin_base_href = $this->getProtocol($secure).
-					$this->getServerName($secure).$admin_base_href;
+			if (mb_substr($admin_base_href, 0, 1) === '/') {
+				$admin_base_href = $this->getProtocol().
+					$this->getServerName().$admin_base_href;
 			}
 		}
 
 		if ($admin_base_href === null) {
-			$admin_base_href = $this->getBaseHref($secure).'admin/';
+			$admin_base_href = $this->getBaseHref().'admin/';
 		}
 
 		return $admin_base_href;
@@ -900,17 +837,14 @@ class SiteWebApplication extends SiteApplication
 	 * anchor values. This allows us to fall back to local images if cdn
 	 * settings get turned off.
 	 *
-	 * @param boolean $secure whether or not the base cdn href should be a
-	 *                         secure URI. The default value of null maintains
-	 *                         the same security as the current page.
-	 *
 	 * @return string the base value for all application cdn anchor hrefs.
 	 */
-	public function getBaseCdnHref($secure = null)
+	public function getBaseCdnHref()
 	{
-		$base_cdn_href = $this->getCdnBase($secure);
+		$base_cdn_href = $this->getCdnBase();
+
 		if ($base_cdn_href === null) {
-			$base_cdn_href = $this->getBaseHref($secure);
+			$base_cdn_href = $this->getBaseHref();
 		}
 
 		return $base_cdn_href;
@@ -922,19 +856,11 @@ class SiteWebApplication extends SiteApplication
 	/**
 	 * Gets the URI relative to the base href
 	 *
-	 * @param boolean $secure whether or not the base href should be a secure
-	 *                         URI. The default value of null maintains the
-	 *                         same security as the current page.
-	 *
 	 * @return string the relative URI
 	 */
-	public function getBaseHrefRelativeUri($secure = null)
+	public function getBaseHrefRelativeUri()
 	{
-		if ($secure === null) {
-			$secure = $this->secure;
-		}
-
-		$base_uri = $this->secure ? $this->secure_base_uri : $this->base_uri;
+		$base_uri = $this->base_uri;
 		$protocol = $this->getProtocol();
 		$protocol_length = mb_strlen($protocol);
 
@@ -944,6 +870,7 @@ class SiteWebApplication extends SiteApplication
 			if ($pos !== false) {
 				$base_uri = mb_substr($base_uri, $pos);
 			}
+		}
 		}
 
 		$base_uri_length = mb_strlen($base_uri);
@@ -955,8 +882,8 @@ class SiteWebApplication extends SiteApplication
 
 		// trim mobile prefix from beginning of relative uri
 		if (isset($this->mobile) && $this->mobile->isMobileUrl() &&
-				$this->mobile->getPrefix() !== null) {
-
+			$this->mobile->getPrefix() !== null
+		) {
 			$uri = mb_substr($uri, mb_strlen($this->mobile->getPrefix()) + 1);
 		}
 
@@ -1006,27 +933,14 @@ class SiteWebApplication extends SiteApplication
 	/**
 	 * Gets the root part of the base-href (usually the protocol and domain)
 	 *
-	 * @param boolean $secure whether or not the base href should be a secure
-	 *                         URI. The default value of null maintains the
-	 *                         same security as the current page.
-	 *
 	 * @return string the root base href.
 	 */
-	protected function getRootBaseHref($secure = null)
+	protected function getRootBaseHref()
 	{
-		if ($secure === null) {
-			$secure = $this->secure;
-		}
-
-		if ($secure) {
-			$base_uri = $this->secure_base_uri;
-		} else {
-			$base_uri = $this->base_uri;
-		}
+		$base_uri = $this->base_uri;
 
 		if (mb_substr($base_uri, 0, 1) === '/') {
-			$base_href = $this->getProtocol($secure).
-				$this->getServerName($secure).$base_uri;
+			$base_href = $this->getProtocol().$this->getServerName().$base_uri;
 		} else {
 			$base_href = $base_uri;
 		}
@@ -1035,62 +949,12 @@ class SiteWebApplication extends SiteApplication
 	}
 
 	// }}}
-	// {{{ protected function getSecureSourceList()
-
-	/**
-	 * Gets the list of pages sources that should be secure
-	 *
-	 * The list of page sources is an array of source strings.
-	 * Entries are regular expressions.
-	 *
-	 * @return array the list of sources that should be secure.
-	 */
-	protected function getSecureSourceList()
-	{
-		return array();
-	}
-
-	// }}}
-	// {{{ protected function checkSecure()
-
-	/**
-	 * Checks if this page should be redirected in/out of SSL
-	 *
-	 * @param string The source string of this page.
-	 */
-	protected function checkSecure($source)
-	{
-		foreach ($this->getSecureSourceList() as $pattern) {
-			$pattern = str_replace('|', '\|', $pattern);
-			$regexp = '|'.$pattern.'|u';
-			if (preg_match($regexp, $source) === 1) {
-				if ($this->secure) {
-					// regenerate the session ID after entering SSL
-					if ($this->hasSession() && isset($this->session->_regenerate_id)) {
-						$this->session->regenerateId();
-						unset($this->session->_regenerate_id);
-					}
-					return;
-				} else {
-					$new_uri = $this->getAbsoluteUri(true);
-
-					// set a flag to regenerate session ID on next request when we'll be in SSL
-					if ($this->hasSession())
-						$this->session->_regenerate_id = true;
-
-					$this->relocate($new_uri, null, true);
-				}
-			}
-		}
-	}
-
-	// }}}
 	// {{{ protected function getAbsoluteUri()
 
-	protected function getAbsoluteUri($secure = null)
+	protected function getAbsoluteUri()
 	{
-		$base_href = $this->getBaseHref($secure);
-		$relative_uri = $this->getBaseHrefRelativeUri($secure);
+		$base_href = $this->getBaseHref();
+		$relative_uri = $this->getBaseHrefRelativeUri();
 		$uri = $base_href.$relative_uri;
 
 		return $uri;
@@ -1122,26 +986,9 @@ class SiteWebApplication extends SiteApplication
 	 *
 	 * @return string the servername
 	 */
-	protected function getServerName($secure = null)
+	protected function getServerName()
 	{
-		$server_name = $_SERVER['HTTP_HOST'];
-
-		if ($secure !== null && $this->secure !== $secure) {
-			/* Need to mangle servername for browsers tunnelling on
-			 * non-standard ports.
-			 */
-			$regexp = '/localhost:[0-9]+/u';
-
-			if (preg_match($regexp, $server_name)) {
-				if ($secure) {
-					$server_name = 'localhost:8443';
-				} else {
-					$server_name = 'localhost:8080';
-				}
-			}
-		}
-
-		return $server_name;
+		return $_SERVER['HTTP_HOST'];
 	}
 
 	// }}}
@@ -1152,13 +999,9 @@ class SiteWebApplication extends SiteApplication
 	 *
 	 * @return string the protocol
 	 */
-	protected function getProtocol($secure = null)
+	protected function getProtocol()
 	{
-		if ($secure === null) {
-			$secure = $this->secure;
-		}
-
-		if ($secure) {
+		if ($this->secure) {
 			$protocol = 'https://';
 		} else {
 			$protocol = 'http://';

--- a/Site/SiteWebApplication.php
+++ b/Site/SiteWebApplication.php
@@ -204,8 +204,8 @@ class SiteWebApplication extends SiteApplication
 	 *
 	 * @param string $uri the URI of the full P3P XML document.
 	 *
-	 * @see http://www.w3.org/P3P/
-	 * @see http://en.wikipedia.org/wiki/P3P
+	 * @see https://www.w3.org/P3P/
+	 * @see https://en.wikipedia.org/wiki/P3P
 	 */
 	public function setP3PPolicyURI($uri)
 	{
@@ -220,8 +220,8 @@ class SiteWebApplication extends SiteApplication
 	 *
 	 * @param string $policy the P3P compact policy.
 	 *
-	 * @see http://www.w3.org/P3P/
-	 * @see http://en.wikipedia.org/wiki/P3P
+	 * @see https://www.w3.org/P3P/
+	 * @see https://en.wikipedia.org/wiki/P3P
 	 */
 	public function setP3PCompactPolicy($policy)
 	{

--- a/Site/admin/components/InstanceSetting/include/config-page.xml
+++ b/Site/admin/components/InstanceSetting/include/config-page.xml
@@ -17,7 +17,7 @@
 	</widget>
 	<widget class="SwatFormField">
 		<property name="title" translatable="yes">Akismet Key</property>
-		<property name="note"><![CDATA[Akismet is for automatic spam filtering. <a href="http://akismet.com/personal/">Get an API key</a>]]></property>
+		<property name="note"><![CDATA[Akismet is for automatic spam filtering. <a href="https://akismet.com/personal/">Get an API key</a>]]></property>
 		<property name="note_content_type">text/xml</property>
 		<widget class="SwatEntry" id="comment_akismet_key">
 			<property name="maxlength" type="integer">255</property>

--- a/Site/dataobjects/SiteAttachment.php
+++ b/Site/dataobjects/SiteAttachment.php
@@ -168,7 +168,7 @@ class SiteAttachment extends SwatDBDataObject
 	 *
 	 * For MPEG-4 Audio, we use the non-standard but universally accepted m4a
 	 * extension. See wikipedia for more details
-	 * {@link http://en.wikipedia.org/wiki/.m4a}
+	 * {@link https://en.wikipedia.org/wiki/.m4a}.
 	 *
 	 * @returns string The extension of the file.
 	 */
@@ -368,7 +368,7 @@ class SiteAttachment extends SwatDBDataObject
 		$headers = array();
 
 		// Set a "never-expire" policy with a far future max age (10 years) as
-		// suggested http://developer.yahoo.com/performance/rules.html#expires.
+		// suggested https://developer.yahoo.com/performance/rules.html#expires.
 		// As well, set Cache-Control to public, as this allows some browsers to
 		// cache the images to disk while on https, which is a good win. This
 		// depends on setting new object ids when updating the object, if this

--- a/Site/dataobjects/SiteImage.php
+++ b/Site/dataobjects/SiteImage.php
@@ -620,8 +620,8 @@ class SiteImage extends SwatDBDataObject
 	 * This is for easy use of the retina technique of allowing the browser to
 	 * down-size a larger lower quality compressed image from its actual size
 	 * to half its size. See
-	 * @link{http://filamentgroup.com/lab/rwd_img_compression/} and
-	 * @link{http://www.netvlies.nl/blog/design-interactie/retina-revolution}
+	 * {@link https://www.filamentgroup.com/lab/compressive-images.html} and
+	 * {@link https://www.netvlies.nl/tips-updates/algemeen/design-interactie/retina-revolution/}
 	 * for a full explanation of this technique. This assumes sane compression
 	 * and resize filter settings have been set on the image dimension being
 	 * displayed.
@@ -659,7 +659,7 @@ class SiteImage extends SwatDBDataObject
 		$headers = array();
 
 		// Set a "never-expire" policy with a far future max age (10 years) as
-		// suggested http://developer.yahoo.com/performance/rules.html#expires.
+		// suggested https://developer.yahoo.com/performance/rules.html#expires.
 		// As well, set Cache-Control to public, as this allows some browsers to
 		// cache the images to disk while on https, which is a good win. This
 		// depends on setting new object ids when updating the object, if this
@@ -1352,7 +1352,7 @@ class SiteImage extends SwatDBDataObject
 	 *
 	 * This works around a upstream limitation of Imagick that does not allow
 	 * cloned objects to get the correct image size. See
-	 * @link{https://bugs.php.net/bug.php?id=64015}.
+	 * {@link https://bugs.php.net/bug.php?id=64015}.
 	 *
 	 * @param SiteImageDimension $dimension the image's dimension.
 	 * @param SiteImageDimensionBinding $dimension_binding the image's

--- a/Site/dataobjects/SiteVideoMedia.php
+++ b/Site/dataobjects/SiteVideoMedia.php
@@ -151,16 +151,6 @@ class SiteVideoMedia extends SiteMedia
 		$jwplayer->menu_title = $app->config->site->title;
 		$jwplayer->menu_link = $app->getBaseHref();
 
-		// Android 2 can not play back video over HTTPS from CloudFront, so
-		// force the sources as HTTP.
-		$secure = $app->isSecure();
-		if ($app->hasModule('SiteMobileModule') &&
-			$app->mobile->isAndroid() &&
-			$app->mobile->getPlatformMajorVersion() !== null &&
-			$app->mobile->getPlatformMajorVersion() == 2) {
-			$secure = false;
-		}
-
 		if ($app->session->isActive()) {
 			$jwplayer->setSession($app->session);
 		}
@@ -171,8 +161,7 @@ class SiteVideoMedia extends SiteMedia
 			$jwplayer->addSource(
 				$app->cdn->getUri(
 					$this->getHlsFilePath(),
-					$expires,
-					$secure
+					$expires
 				)
 			);
 		}
@@ -187,8 +176,7 @@ class SiteVideoMedia extends SiteMedia
 				$jwplayer->addSource(
 					$app->cdn->getUri(
 						$this->getFilePath($encoding->shortname),
-						$expires,
-						$secure
+						$expires
 					),
 					$binding->width,
 					$binding->height.'p');


### PR DESCRIPTION
## Changes
- Removes config values for secure base URI. All pages in the application get the same level of protocol security.

### SiteWebApplication
- Keeps protocol parsing and proxy header parsing to check if app is secure.
- Removes `getSecureSourceList()`. All pages are considered to have the same level of protocol security.
- Removes `checkSecure()` method that checks and redirects to secure URLs since all pages have the same level of protocol security.
- Removes APIs to explicitly chose secure vs insecure links. External links are always returned as secure, internal links always use the parsed protocol/header security level.

### SiteAmazonCdnModule
- Makes CDN URLs always secure

### SiteMedia
- Removes Android 2.x fallback URLs. These devices are not supported.