### PR TITLE
Fix timestamp format in WebVTT files

### DIFF
--- a/Site/pages/SiteVideoTextTracksPage.php
+++ b/Site/pages/SiteVideoTextTracksPage.php
@@ -144,8 +144,12 @@ class SiteVideoTextTracksPage extends SitePage
 			$seconds -= $minute * $minutes;
 		}
 
-		return sprintf('%02d:%02d:%02d,000',
-			$hours, $minutes, $seconds);
+		return sprintf(
+			'%02d:%02d:%02d.000',
+			$hours,
+			$minutes,
+			$seconds
+		);
 	}
 
 	// }}}


### PR DESCRIPTION
The timestamp format must be `00:00:00.000` and not `00:00:00,000`

See https://support.jwplayer.com/articles/how-to-add-preview-thumbnails#vtt-example and https://www.w3.org/TR/webvtt1/#webvtt-timestamp

Testing
------
1. check out PR
2. on `roble` go to the hippo site
3. run `gulp --symlinks=site`
4. load https://hippostage.silverorange.com/hippo-em/work-gauthierm/www/vtt/4416.vtt
5. paste file content in https://quuz.org/webvtt/ to validate