### PR TITLE
Prevent all dimensions from being re-processed.

### DIFF
--- a/Site/dataobjects/SiteImage.php
+++ b/Site/dataobjects/SiteImage.php
@@ -858,10 +858,16 @@ class SiteImage extends SwatDBDataObject
 
 	public function processMissingDimensions($image_file)
 	{
+		$shortnames = [];
 		foreach ($this->getImageSet()->dimensions as $dimension) {
 			if (!$this->hasDimension($dimension->shortname)) {
-				$this->processManual($image_file, $dimension->shortname);
+				$shortnames[] = $dimension->shortname;
+
 			}
+		}
+
+		foreach ($shortnames as $shortname) {
+			$this->processManual($image_file, $shortname);
 		}
 	}
 


### PR DESCRIPTION
Calling processManual() will in turn call prepareForProcessing(). That
method resets the image dimensions bindings to an empty collection.
Since that collection is noe empty but we are still in the loop all
further calls to hasDimensionBinding will be false which will cause all
dimensions to be processed instead of just the missing ones.