### PR TITLE
update to display media key for every video on the page

### DIFF
--- a/Site/SiteJwPlayerMediaDisplay.php
+++ b/Site/SiteJwPlayerMediaDisplay.php
@@ -246,13 +246,8 @@ class SiteJwPlayerMediaDisplay extends SwatControl
 		}
 
 		if ($this->key !== null) {
-			static $key_included = false;
-
-			if (!$key_included) {
-				$key_included = true;
-				Swat::displayInlineJavaScript(sprintf('jwplayer.key = %s;',
-					SwatString::quoteJavaScriptString($this->key)));
-			}
+			Swat::displayInlineJavaScript(sprintf('jwplayer.key = %s;',
+				SwatString::quoteJavaScriptString($this->key)));
 		}
 
 		echo '<div class="video-player-container">';


### PR DESCRIPTION
This pr updates to display media key for every video on the page. This is to help avoid bug discussed in this thread: https://silverorange.slack.com/archives/C04QTJ736/p1612361977193700
