### PR TITLE
Replace PEAR mail with Symfony mail

### DIFF
--- a/Site/SiteMultipartMailMessage.php
+++ b/Site/SiteMultipartMailMessage.php
@@ -235,7 +235,7 @@ class SiteMultipartMailMessage extends SiteObject
 				);
 			}
 
-			$dsn = "smtp://";
+			$dsn = 'smtp://';
 
 			if ($this->smtp_username != '') {
 				$dsn.= $this->smtp_username;
@@ -249,7 +249,12 @@ class SiteMultipartMailMessage extends SiteObject
 
 			if ($this->smtp_port != '') {
 				$dsn.= ':'.$this->smtp_port;
+			} else {
+				// Default port of 25
+				$dsn.= ':25';
 			}
+
+			$dsn.= '?verify_peer=0';
 
 			$mailer = new Mailer(Transport::fromDsn($dsn));
 

--- a/composer.json
+++ b/composer.json
@@ -46,15 +46,14 @@
 		"ext-pcre": "*",
 		"aws/aws-sdk-php": "^3.0.0",
 		"codescale/ffmpeg-php": "^2.7.0",
-		"pear/mail": "^1.2.0",
-		"pear/mail_mime": "^1.10.0",
 		"pear/net_smtp": "^1.6.3",
 		"pear/services_akismet2": ">=0.3.1",
 		"pear/text_password": "^1.1.1",
 		"sentry/sdk": "^3.2",
 		"silverorange/mdb2": "^3.0.0",
 		"silverorange/concentrate": "^2.0.0",
-		"silverorange/swat": "^5.4.1 || ^6.0.0"
+		"silverorange/swat": "^5.4.1 || ^6.0.0",
+		"symfony/mailer": "^5.4"
 	},
 	"require-dev": {
 		"silverorange/coding-standard": "^1.0.0"


### PR DESCRIPTION
Testing Instructions for course host (bernaphp8)

1) Check out this PR in `/so/packages/site/work-{name}`
2) In `/so/sites/course-host/work-{name}`, `composer install && composer upgrade silverorange/mdb2_driver_pgsql silverorange/store`.
3) Change config -> platform -> php to 7.3 in composer.json.
4) `composer require symfony/mailer`
5) Link the site code using symfony mailer, `rm -r vendor/silverorange/site && ln -s /so/packages/site/work-{name} vendor/silverorange/site`
6) Change `test_address` in `course-host.ini` to `name@silverorange.com`
6) Trigger something with emails (e.g, buying a course).