### PR TITLE
Replace PEAR mail with PHPMailer

### DIFF
--- a/Site/SiteMultipartMailMessage.php
+++ b/Site/SiteMultipartMailMessage.php
@@ -244,7 +244,13 @@ class SiteMultipartMailMessage extends SiteObject
 			}
 
 			$mailer->isSMTP();
-			$mailer->host = $this->smtp_server;
+			$mailer->Host = $this->smtp_server;
+
+			$mailer->SMTPOptions = array(
+				'ssl' => array(
+					'verify_peer_name' => false
+				)
+			);
 
 			if ($this->smtp_port != '') {
 				$mailer->Port = $this->smtp_port;

--- a/composer.json
+++ b/composer.json
@@ -46,15 +46,14 @@
 		"ext-pcre": "*",
 		"aws/aws-sdk-php": "^3.0.0",
 		"codescale/ffmpeg-php": "^2.7.0",
-		"pear/mail": "^1.2.0",
-		"pear/mail_mime": "^1.10.0",
 		"pear/net_smtp": "^1.6.3",
 		"pear/services_akismet2": ">=0.3.1",
 		"pear/text_password": "^1.1.1",
 		"sentry/sentry": "^1.7.0",
 		"silverorange/mdb2": "^3.0.0",
 		"silverorange/concentrate": "^2.0.0",
-		"silverorange/swat": "^5.4.1 || ^6.0.0"
+		"silverorange/swat": "^5.4.1 || ^6.0.0",
+		"phpmailer/phpmailer": "^6.6"
 	},
 	"require-dev": {
 		"silverorange/coding-standard": "^1.0.0"


### PR DESCRIPTION
Testing Instructions for course host (bernaphp8)

1) Check out this PR in `/so/packages/site/work-{name}`
2) In `/so/sites/course-host/work-{name}`, `composer install && composer upgrade silverorange/mdb2_driver_pgsql silverorange/store`.
3) `composer require phpmailer/phpmailer`
5) Link the site code using phpmailer, `rm -r vendor/silverorange/site && ln -s /so/packages/site/work-{name} vendor/silverorange/site`
6) Change `test_address` in `course-host.ini` to `name@silverorange.com`
6) Trigger something with emails (e.g, buying a course).