### PR TITLE
Fix private final function:

### DIFF
--- a/Site/SiteReplacementMarkerMailMessage.php
+++ b/Site/SiteReplacementMarkerMailMessage.php
@@ -66,7 +66,7 @@ abstract class SiteReplacementMarkerMailMessage extends SiteMultipartMailMessage
 	}
 
 	// }}}
-	// {{{ private final function getReplacementMarkerTextByMatches()
+	// {{{ private function getReplacementMarkerTextByMatches()
 
 	/**
 	 * Gets replacement text for a replacement marker from within a matches
@@ -77,7 +77,7 @@ abstract class SiteReplacementMarkerMailMessage extends SiteMultipartMailMessage
 	 * @return string the replacement text for the first parenthesized
 	 *                 subpattern of the <i>$matches</i> array.
 	 */
-	private final function getReplacementMarkerTextByMatches($matches)
+	private function getReplacementMarkerTextByMatches($matches)
 	{
 		if (isset($matches[1]))
 			return $this->getReplacementMarkerText($matches[1]);

--- a/Site/pages/SiteArticlePage.php
+++ b/Site/pages/SiteArticlePage.php
@@ -254,7 +254,7 @@ class SiteArticlePage extends SitePathPage
 	}
 
 	// }}}
-	// {{{ private final function getReplacementMarkerTextByMatches()
+	// {{{ private function getReplacementMarkerTextByMatches()
 
 	/**
 	 * Gets replacement text for a replacement marker from within a matches
@@ -265,7 +265,7 @@ class SiteArticlePage extends SitePathPage
 	 * @return string the replacement text for the first parenthesized
 	 *                 subpattern of the <i>$matches</i> array.
 	 */
-	private final function getReplacementMarkerTextByMatches($matches)
+	private function getReplacementMarkerTextByMatches($matches)
 	{
 		if (isset($matches[1]))
 			return $this->getReplacementMarkerText($matches[1]);


### PR DESCRIPTION
Remove final modifier from all (except __construct) private methods per
php8 compatibility.
private final function foo()
to
private function foo()