### PR TITLE
Upgrade Sentry package two major versions

### DIFF
--- a/Site/SiteSentryErrorLogger.php
+++ b/Site/SiteSentryErrorLogger.php
@@ -11,26 +11,15 @@ class SiteSentryErrorLogger extends SiteErrorLogger
 {
 	// {{{ protected properties
 
-	/**
-	 * Client that is used to send error details to sentry
-	 *
-	 * Instantiated with dsn elsewhere and then provided in construct
-	 *
-	 * @var Raven_Client
-	 */
-	protected $client;
-
 	// }}}
 	// {{{ public function __construct()
 
 	/**
 	 * Creates a new sentry error loggger
 	 *
-	 * @param Raven_Client $client the sentry client to use
 	 */
-	public function __construct(Raven_Client $client)
+	public function __construct()
 	{
-		$this->client = $client;
 	}
 
 	// }}}
@@ -44,7 +33,7 @@ class SiteSentryErrorLogger extends SiteErrorLogger
 	public function log(SwatError $e)
 	{
 		if (!$this->filter($e)) {
-			$this->client->captureException(
+			\Sentry\captureException(
 				new ErrorException(
 					$e->getMessage(),
 					0,

--- a/Site/SiteSentryExceptionLogger.php
+++ b/Site/SiteSentryExceptionLogger.php
@@ -9,28 +9,14 @@
  */
 class SiteSentryExceptionLogger extends SiteExceptionLogger
 {
-	// {{{ protected properties
-
-	/**
-	 * Client that is used to send exception details to sentry
-	 *
-	 * Instantiated with dsn elsewhere and then provided in construct
-	 *
-	 * @var Raven_Client
-	 */
-	protected $client;
-
-	// }}}
 	// {{{ public function __construct()
 
 	/**
 	 * Creates a new sentry exception loggger
 	 *
-	 * @param Raven_Client $client the sentry client to use
 	 */
-	public function __construct(Raven_Client $client)
+	public function __construct()
 	{
-		$this->client = $client;
 	}
 
 	// }}}
@@ -44,7 +30,7 @@ class SiteSentryExceptionLogger extends SiteExceptionLogger
 	public function log(SwatException $e)
 	{
 		if (!$e instanceof SiteNotFoundException) {
-			$this->client->captureException($e);
+			\Sentry\captureException($e);
 		}
 	}
 

--- a/Site/SiteSessionModule.php
+++ b/Site/SiteSessionModule.php
@@ -740,10 +740,9 @@ class SiteSessionModule extends SiteApplicationModule
 	 */
 	protected function setSentryUserContext()
 	{
-		$client = $this->app->getSentryClient();
-		if ($client instanceof Raven_Client) {
-			$client->user_context($this->getErrorUserContext());
-		}
+		\Sentry\configureScope(function (\Sentry\State\Scope $scope): void {
+			$scope->setUser($this->getErrorUserContext());
+		});
 	}
 
 	// }}}

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 		"pear/net_smtp": "^1.6.3",
 		"pear/services_akismet2": ">=0.3.1",
 		"pear/text_password": "^1.1.1",
-		"sentry/sentry": "^1.7.0",
+		"sentry/sdk": "^3.2",
 		"silverorange/mdb2": "^3.0.0",
 		"silverorange/concentrate": "^2.0.0",
 		"silverorange/swat": "^5.4.1 || ^6.0.0"


### PR DESCRIPTION
Previous to this PR, we were using Sentry 1.7.0. Unfortunately, this
version of Sentry is not PHP8 compatible. This PR upgrades our Sentry
package to version 3.0, which is compatible with both PHP7 and PHP8.

My testing setup (for coursehost):

1) Checkout this PR
2) Go to course-host, `composer install`
3) If testing on PHP8, `composer update silverorange/mdb2_driver_pgsql`
4) In course-host composer.json, add:

```
               {
                       "type": "path",
                       "url": "/so/packages/site/work-name",
                       "options": {
                               "symlink": true
                       }
              },
```

to your list of repositories (I believe it has to be the first one in the list, since composer uses the order for precedence). Replace the version of silverorange/site in composer.json with `dev-master as 10.2.1`
5) `composer update silverorange/site -W`
6) Place an exception somewhere in the coursehost code, (I did mine in the CCME front page), check that it gets registered in Sentry

This will require a major release since we're deprecating the getSentryClient method