### PR TITLE
Upgrade ffmpeg package up a major version

### DIFF
--- a/Site/SiteVideoScrubberImageGenerator.php
+++ b/Site/SiteVideoScrubberImageGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+use Char0n\FFMpegPHP\Movie;
+
 /**
  * Generates media thumbnails for the video scrubber
  *
@@ -169,7 +171,7 @@ class SiteVideoScrubberImageGenerator extends
 
 	protected function processMedia(SiteMedia $media, $path)
 	{
-		$movie = new FFmpegMovie($path);
+		$movie = new Movie($path);
 		$grid = new Imagick();
 
 		$position = 0;

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"ext-openssl": "*",
 		"ext-pcre": "*",
 		"aws/aws-sdk-php": "^3.0.0",
-		"codescale/ffmpeg-php": "^2.7.0",
+		"codescale/ffmpeg-php": "^3.2.0",
 		"pear/net_smtp": "^1.6.3",
 		"pear/services_akismet2": ">=0.3.1",
 		"pear/text_password": "^1.1.1",


### PR DESCRIPTION
The methods we use in the ffmpeg package are `getDuration` and `getFrameAtTime`, which also exist in the new version. We just need to use the new class since it's now namespaced.

http://char0n.github.io/ffmpeg-php/classes/Char0n-FFMpegPHP-Movie.html

Will require a minor version
