### PR TITLE
Deprecate akismet since no sites use it

### DIFF
--- a/Site/Site.php
+++ b/Site/Site.php
@@ -296,9 +296,6 @@ class Site
 			'memcache.resource_cache'      => true,
 			'memcache.resource_cache_stat' => true,
 
-			// comments
-			'comment.akismet_key'      => null,
-
 			// amazon AWS
 			// @see https://docs.aws.amazon.com/general/latest/gr/rande.html
 			'amazon.region' => 'us-east-1',

--- a/Site/SiteCommentUi.php
+++ b/Site/SiteCommentUi.php
@@ -272,30 +272,7 @@ abstract class SiteCommentUi
 
 	protected function isCommentSpam(SiteComment $comment)
 	{
-		$is_spam = false;
-
-		if ($this->app->config->comment->akismet_key !== null) {
-			$uri = $this->app->getBaseHref();
-			try {
-				$akismet = new Services_Akismet2($uri,
-					$this->app->config->comment->akismet_key);
-
-				$akismet_comment = new Services_Akismet2_Comment(
-					array(
-						'comment_author'       => $comment->fullname,
-						'comment_author_email' => $comment->email,
-						'comment_author_url'   => $comment->link,
-						'comment_content'      => $comment->bodytext,
-						'permalink'            => $this->getPermalink($comment),
-					)
-				);
-
-				$is_spam = $akismet->isSpam($akismet_comment, true);
-			} catch (Exception $e) {
-			}
-		}
-
-		return $is_spam;
+		return false;
 	}
 
 	// }}}

--- a/Site/admin/components/Comment/AjaxServer.php
+++ b/Site/admin/components/Comment/AjaxServer.php
@@ -24,20 +24,6 @@ abstract class SiteCommentAjaxServer extends SiteXMLRPCServer
 
 		if ($comment !== null) {
 			if (!$comment->spam) {
-				// submit spam to akismet
-				if ($this->app->config->comment->akismet_key !== null) {
-					$uri = $this->app->getFrontendBaseHref();
-					try {
-						$akismet = new Services_Akismet2($uri,
-							$this->app->config->comment->akismet_key);
-
-						$akismet_comment = $this->getAkismetComment($comment);
-
-						$akismet->submitSpam($akismet_comment);
-					} catch (Exception $e) {
-					}
-				}
-
 				$comment->spam = true;
 				$comment->save();
 				$comment->postSave($this->app);
@@ -62,21 +48,6 @@ abstract class SiteCommentAjaxServer extends SiteXMLRPCServer
 		$comment = $this->getComment($comment_id);
 		if ($comment !== null) {
 			if ($comment->spam) {
-
-				// submit false positive to akismet
-				if ($this->app->config->comment->akismet_key !== null) {
-					$uri = $this->app->getFrontendBaseHref();
-					try {
-						$akismet = new Services_Akismet2($uri,
-							$this->app->config->comment->akismet_key);
-
-						$akismet_comment = $this->getAkismetComment($comment);
-
-						$akismet->submitFalsePositive($akismet_comment);
-					} catch (Exception $e) {
-					}
-				}
-
 				$comment->spam = false;
 				$comment->save();
 				$comment->postSave($this->app);

--- a/Site/admin/components/InstanceSetting/include/SiteConfigPage.php
+++ b/Site/admin/components/InstanceSetting/include/SiteConfigPage.php
@@ -27,9 +27,6 @@ class SiteConfigPage extends SiteAbstractConfigPage
 				'title',
 				'meta_description',
 			),
-			'comment' => array(
-				'akismet_key',
-			),
 			'date' => array(
 				'time_zone',
 			),

--- a/Site/admin/components/InstanceSetting/include/config-page.xml
+++ b/Site/admin/components/InstanceSetting/include/config-page.xml
@@ -15,12 +15,4 @@
 		<property name="title" translatable="yes">Time Zone</property>
 		<widget class="SwatTimeZoneEntry" id="date_time_zone" />
 	</widget>
-	<widget class="SwatFormField">
-		<property name="title" translatable="yes">Akismet Key</property>
-		<property name="note"><![CDATA[Akismet is for automatic spam filtering. <a href="https://akismet.com/personal/">Get an API key</a>]]></property>
-		<property name="note_content_type">text/xml</property>
-		<widget class="SwatEntry" id="comment_akismet_key">
-			<property name="maxlength" type="integer">255</property>
-		</widget>
-	</widget>
 </swatml>

--- a/Site/pages/SiteCommentAddPage.php
+++ b/Site/pages/SiteCommentAddPage.php
@@ -231,32 +231,7 @@ abstract class SiteCommentAddPage extends SitePageDecorator
 
 	protected function isSpam()
 	{
-		$is_spam = false;
-
-		if ($this->app->config->comment->akismet_key !== null) {
-			$uri = $this->app->getBaseHref();
-			try {
-				$akismet = new Services_Akismet2(
-					$uri,
-					$this->app->config->comment->akismet_key
-				);
-
-				$akismet_comment = new Services_Akismet2_Comment(
-					array(
-						'comment_author'       => $this->comment->fullname,
-						'comment_author_email' => $this->comment->email,
-						'comment_author_url'   => $this->comment->link,
-						'comment_content'      => $this->comment->bodytext,
-						'permalink'            => $this->getPermalink($comment),
-					)
-				);
-
-				$is_spam = $akismet->isSpam($akismet_comment, true);
-			} catch (Exception $e) {
-			}
-		}
-
-		return $is_spam;
+		return false;
 	}
 
 	// }}}

--- a/Site/pages/SiteContactPage.php
+++ b/Site/pages/SiteContactPage.php
@@ -167,44 +167,7 @@ class SiteContactPage extends SiteDBEditPage
 
 	protected function isMessageSpam(SiteContactMessage $message)
 	{
-		$is_spam = false;
-
-		if ($this->app->config->comment->akismet_key != '') {
-			$uri = $this->app->getBaseHref();
-			try {
-				$akismet = new Services_Akismet2(
-					$uri,
-					$this->app->config->comment->akismet_key
-				);
-
-				$is_spam = $akismet->isSpam(
-					$this->getAkismetComment($message),
-					true
-				);
-			} catch (Exception $e) {
-			}
-		}
-
-		return $is_spam;
-	}
-
-	// }}}
-	// {{{ protected function getAkismetComment()
-
-	protected function getAkismetComment(SiteContactMessage $message)
-	{
-		$uri = $this->app->getBaseHref();
-
-		return new Services_Akismet2_Comment(
-			array(
-				'comment_author_email' => $message->email,
-				'comment_content'      => $message->message,
-				'comment_type'         => 'comment',
-				'permalink'            => $uri.$this->source,
-				'user_ip'              => $message->ip_address,
-				'user_agent'           => $message->user_agent,
-			)
-		);
+		return false;
 	}
 
 	// }}}

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
 		"ext-pcre": "*",
 		"aws/aws-sdk-php": "^3.0.0",
 		"codescale/ffmpeg-php": "^3.2.0",
-		"pear/services_akismet2": ">=0.3.1",
 		"pear/text_password": "^1.1.1",
 		"sentry/sdk": "^3.2",
 		"silverorange/mdb2": "^3.0.0",


### PR DESCRIPTION
Search Slack for akismet and you'll find that the last message was from 2017, where Isa cancelled the subscriptions. Since the package hasn't been upgraded since 2010, it seems ideal to deprecate our akismet support.

I just searched through VSCode for all references for the term "akismet" and removed all of them.

Will require a major version upgrade
