### PR TITLE
Remove unnecessary Net_SMTP dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
 		"ext-pcre": "*",
 		"aws/aws-sdk-php": "^3.0.0",
 		"codescale/ffmpeg-php": "^3.2.0",
-		"pear/net_smtp": "^1.6.3",
 		"pear/services_akismet2": ">=0.3.1",
 		"pear/text_password": "^1.1.1",
 		"sentry/sdk": "^3.2",


### PR DESCRIPTION
This was used by pear/mail, but since we're now using symfony mail, Net_SMTP is no longer necessary. If you search for 'Net_SMTP' in Site, (even in the vendor files), you'll see no references (apart from the vendor file defining net_smtp).