### PR TITLE
Fix mail message w/ only txt displaying html

### DIFF
--- a/Site/SiteMultipartMailMessage.php
+++ b/Site/SiteMultipartMailMessage.php
@@ -211,8 +211,11 @@ class SiteMultipartMailMessage extends SiteObject
 					$this->from_address,
 					$this->from_name
 				))
-				->text($this->text_body)
-				->html($this->convertCssToInlineStyles($this->html_body));
+				->text($this->text_body);
+
+			if ($this->html_body != '') {
+				$email->html($this->convertCssToInlineStyles($this->html_body));
+			}
 
 			// don't send CC emails if test-address is specified
 			if ($this->app->config->email->test_address == '') {


### PR DESCRIPTION
This is a bug based on the differences between Symfony mail and PEAR
Mail. In the previous implementation based on PEAR Mail, if the html
body was set to the empty string, no HTML portion would be included in
the email request. In symfony, calling ->html on an email will
prioritize html being displayed even if the html portion is empty and
the txt portion is populated.

This causes a bug in places where we only use TXT, namely, the
coursehost contact page. Although all relevant information will be
included in the email, by default the empty HTML will be displayed.
This means users will have to inspect the source of the email message
to see the txt body.

The simple fix is to only call ->html if the string is nonempty