### PR TITLE
Explicitly use the Php XML-RPC backend to avoid bugs with native backend

### DIFF
--- a/Site/pages/SiteXMLRPCServer.php
+++ b/Site/pages/SiteXMLRPCServer.php
@@ -28,13 +28,14 @@ abstract class SiteXMLRPCServer extends SitePage
 	 */
 	public function process()
 	{
-		$server = XML_RPC2_Server::create(
-			$this,
-			array(
-				'encoding' => 'utf-8',
-				'input'    => 'XML_RPC2_Server_Input_PhpInput',
-			)
-		);
+		$server = XML_RPC2_Server::create($this, array(
+			'encoding' => 'utf-8',
+			'input' => 'XML_RPC2_Server_Input_PhpInput',
+			// Explicitly select the PHP backend. The native backend has
+			// trouble with UTF-8 encoding and with properly parsing
+			// method parameters.
+			'backend' => 'Php'
+		));
 
 		$this->layout->startCapture('response');
 		$server->handleCall();


### PR DESCRIPTION
On our servers, the native extension is not included so Php gets used by default. If we try to run in an environment where the native extension is present, it gets selected by default and has the following bugs:

 - UTF-8 non ASCII characters get broken encoding
 - method calls with no parameters parse the parameters as null instead of an empty array, causing a PHP warning