### PR TITLE
Set the process time zone explicitly in the contructor

### DIFF
--- a/Site/SiteWebApplication.php
+++ b/Site/SiteWebApplication.php
@@ -60,6 +60,18 @@ class SiteWebApplication extends SiteApplication
 	protected $p3p_compact_policy = '';
 
 	// }}}
+	// {{{ public function __construct()
+
+	public function __construct($id, $config_filename = null)
+	{
+		// Web applications expect the local environment time zone to be UTC
+		// by default. If this is not set, some dates will incorrectly be
+		// initialized with local time.
+		date_default_timezone_set('UTC');
+		parent::__construct($id, $config_filename);
+	}
+
+	// }}}
 	// {{{ public static function cleanUriGetVar()
 
 	/**


### PR DESCRIPTION
Web applications in this framework expect to be in UTC. This changes from requiring the environment be configured, to setting the time zone in the application.

Explicitly setting UTC ensures compatility with legacy code.