### PR TITLE
Improve image schema strictness

### DIFF
--- a/sql/pgsql/tables/ImageDimension.sql
+++ b/sql/pgsql/tables/ImageDimension.sql
@@ -1,7 +1,7 @@
 create table ImageDimension (
 	id serial,
 	image_set integer not null references ImageSet(id) on delete cascade,
-	default_type integer references ImageType(id) on delete cascade,
+	default_type integer not null references ImageType(id) on delete cascade,
 	shortname varchar(255),
 	title varchar(255),
 	max_width integer,

--- a/sql/pgsql/tables/ImageType.sql
+++ b/sql/pgsql/tables/ImageType.sql
@@ -1,6 +1,6 @@
 create table ImageType (
 	id serial,
-	extension varchar(10),
-	mime_type varchar(50),
+	extension varchar(10) not null,
+	mime_type varchar(50) not null,
 	primary key(id)
 );


### PR DESCRIPTION
It doesn't make sense for the columns on image type to be optional.

We used to use a null type to mean keep the same type of the image but there hasn't been a use case for that in years so we'll be more strict.