### PR TITLE
urlencode the user, password, and server as per Symfony docs

### DIFF
--- a/Site/SiteMultipartMailMessage.php
+++ b/Site/SiteMultipartMailMessage.php
@@ -241,14 +241,14 @@ class SiteMultipartMailMessage extends SiteObject
 			$dsn = 'smtp://';
 
 			if ($this->smtp_username != '') {
-				$dsn.= $this->smtp_username;
+				$dsn.= urlencode($this->smtp_username);
 				if ($this->smtp_password != '') {
-					$dsn.= ':'.$this->smtp_password;
+					$dsn.= ':'.urlencode($this->smtp_password);
 				}
 				$dsn.= '@';
 			}
 
-			$dsn.= $this->smtp_server;
+			$dsn.= urlencode($this->smtp_server);
 
 			if ($this->smtp_port != '') {
 				$dsn.= ':'.$this->smtp_port;


### PR DESCRIPTION
As per https://symfony.com/doc/current/mailer.html#transport-setup:

> If the username, password or host contain any character considered special in a URI (such as `: / ? # [ ] @ ! $ & ' ( ) * + , ; =`), you must encode them. See [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) for the full list of reserved characters or use the [urlencode](https://secure.php.net/manual/en/function.urlencode.php) function to encode them.

Since we will likely be using an email address (containing a `@`) as the username when pushing email through Mandrill/Mailchimp, we need to encode these values.