### PR TITLE
Google Analytics 4 make instance aware (aoa)

### DIFF
--- a/Site/Site.php
+++ b/Site/Site.php
@@ -236,6 +236,7 @@ class Site
 			'analytics.enabled'                          => true,
 			'analytics.google_account'                   => null,
 			'analytics.google4_account'                  => null,
+			'analytics.google4_account_aoa'              => null,
 
 			// Google analytics account id (XXXXXXXX)
 			'analytics.google_account_id'                => null,

--- a/Site/SiteAnalyticsModule.php
+++ b/Site/SiteAnalyticsModule.php
@@ -47,6 +47,13 @@ class SiteAnalyticsModule extends SiteApplicationModule
 	protected $google4_account;
 
 	/**
+	 * Google Analytics 4 Account AOA instance
+	 *
+	 * @var string
+	 */
+	protected $google4_account_aoa;
+
+	/**
 	 * Flag to tell whether analytics are enabled on this site.
 	 *
 	 * @var boolean
@@ -167,7 +174,15 @@ class SiteAnalyticsModule extends SiteApplicationModule
 		$this->enhanced_link_attribution =
 			$config->analytics->google_enhanced_link_attribution;
 
-		$this->google4_account = $config->analytics->google4_account;
+		$instance = $this->app->hasModule('SiteMultipleInstanceModule')
+			? $this->app->instance->getInstance()
+			: null;
+
+		$this->google4_account =
+			$instance?->shortname === 'aoa'
+				? $config->analytics->google4_account_aoa
+				: $config->analytics->google4_account;
+
 		$this->enhanced_link_attribution =
 			$config->analytics->google_enhanced_link_attribution;
 


### PR DESCRIPTION
# Description 

**Google Analytics 4 (GA4)** - Use separate gtag code specific to instance, ccme (default) or aoa

# Testing

Paired with ( https://github.com/silverorange/course-host/pull/2338 )

`pnpm start start --symlinks=site`

**AOA**
https://berna.silverorange.com/course-host-aoa/work-USERNAME/www/
Check for HTML <head> script tag:
`<script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXX"></script>`
(`id=` then the value of config ini `google4_account_aoa`)

**CCME**
https://berna.silverorange.com/course-host-ccme/work-USERNAME/www/
Check for HTML <head> script tag:
`<script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js?id=G-DYP9FK1Y87"></script>`
