### PR TITLE
Extract sentry config and upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 # misc
 .DS_Store
 .env
+.idea/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/Site/SiteApplication.php
+++ b/Site/SiteApplication.php
@@ -384,12 +384,25 @@ abstract class SiteApplication extends SiteObject
 
 	/**
 	 * Configures sentry based error and exception handling of this application
-	 *
-	 * @param SiteConfigModule $config the config module of this application.
 	 */
-	protected function setUpSentryErrorHandling(SiteConfigModule $config)
+	protected function setUpSentryErrorHandling(SiteConfigModule $config): void
 	{
-		\Sentry\Init([
+		\Sentry\Init($this->getSentryConfiguration($config));
+
+		SwatException::addLogger(new SiteSentryExceptionLogger());
+		SwatError::addLogger(new SiteSentryErrorLogger());
+	}
+
+	// }}}
+	// {{{ protected function getSentryConfiguration()
+
+	/**
+	 * Gets the configuration array used to set up Sentry, which can be
+	 * overridden in child application classes.
+	 */
+	protected function getSentryConfiguration(SiteConfigModule $config): array
+	{
+		return [
 			'dsn' => $config->sentry->dsn,
 			'environment' => $config->sentry->environment,
 			'default_integrations' => false,
@@ -397,10 +410,7 @@ abstract class SiteApplication extends SiteObject
 			'integrations' => [
 				new \Sentry\Integration\FatalErrorListenerIntegration()
 			]
-		]);
-
-		SwatException::addLogger(new SiteSentryExceptionLogger());
-		SwatError::addLogger(new SiteSentryErrorLogger());
+		];
 	}
 
 	// }}}

--- a/composer.json
+++ b/composer.json
@@ -40,16 +40,18 @@
 	],
 	"require": {
 		"php": ">=8.1.0",
+		"ext-curl": "*",
 		"ext-iconv": "*",
+		"ext-json": "*",
 		"ext-mbstring": "*",
 		"ext-openssl": "*",
 		"ext-pcre": "*",
 		"aws/aws-sdk-php": "^3.0.0",
 		"codescale/ffmpeg-php": "^3.2.0",
 		"pear/text_password": "^1.1.1",
-		"sentry/sdk": "^3.2",
-		"silverorange/mdb2": "^3.0.0",
+		"sentry/sentry": "^4.9",
 		"silverorange/concentrate": "^2.0.0",
+		"silverorange/mdb2": "^3.0.0",
 		"silverorange/swat": "^7.1.0",
 		"symfony/mailer": "^5.4"
 	},
@@ -75,5 +77,8 @@
 	},
 	"autoload": {
 		"classmap": [ "Site/" ]
+	},
+	"config": {
+		"sort-packages": true
 	}
 }


### PR DESCRIPTION
This PR does two things:

1. Extracts out a new `getSentryConfiguration()` method.  This method should return the array used in `\Sentry\init()`.  We extract it so that it can be more easily overridden in classes that extend `SiteApplication` (without having to override the entire `setUpSentryErrorHandling()` method).

2. Bumps Sentry from version ^3.2 to ^4.9.  The initialization of Sentry is the same between versions (with the ability to now do more things).  Reading through the changelogs, I don't see any backwards compatibility issues between the versions that would affect us:
    - https://github.com/getsentry/sentry-php/blob/master/UPGRADE-4.0.md
    - https://github.com/getsentry/sentry-php/blob/master/CHANGELOG.md
    - https://github.com/getsentry/sentry-php/blob/3.x/CHANGELOG.md

Whether we want to tag this with a new major or minor version I leave to discussion.