### PR TITLE
Improve concentrate data finder

### DIFF
--- a/Site/SiteConcentrateFileFinder.php
+++ b/Site/SiteConcentrateFileFinder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright 2010-2016 silverorange
+ * @copyright 2010-2024 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SiteConcentrateFileFinder implements Concentrate_DataProvider_FileFinderInterface
@@ -95,48 +95,5 @@ class SiteConcentrateFileFinder implements Concentrate_DataProvider_FileFinderIn
         }
 
         return $files;
-    }
-
-    protected function getDevelopmentDataFiles($include_dir)
-    {
-        $files = [];
-
-        $dependency_dir = $include_dir . DIRECTORY_SEPARATOR . 'dependencies';
-
-        $finder = new Concentrate_DataProvider_FileFinderDirectory(
-            $dependency_dir
-        );
-
-        foreach ($finder->getDataFiles() as $filename) {
-            $key = $this->getDevelopmentKey($filename);
-            if (!isset($files[$key])) {
-                $files[$key] = $filename;
-            }
-        }
-
-        return $files;
-    }
-
-    protected function getDevelopmentKey($filename)
-    {
-        $key = $filename;
-
-        $matches = [];
-        $expression = '!packages/(.*)?/.*?/dependencies/(.*)?$!';
-        if (preg_match($expression, $filename, $matches) === 1) {
-            $key = mb_strtolower($matches[1]) . '/' . $matches[2];
-        }
-
-        return $key;
-    }
-
-    protected function getIncludeDirs()
-    {
-        $include_path = get_include_path();
-
-        $dirs = explode(PATH_SEPARATOR, $include_path);
-        $dirs[] = '..';
-
-        return $dirs;
     }
 }

--- a/Site/SiteConcentrateFileFinder.php
+++ b/Site/SiteConcentrateFileFinder.php
@@ -10,10 +10,10 @@ class SiteConcentrateFileFinder implements Concentrate_DataProvider_FileFinderIn
     {
         // Load data files from composer module directories and from site
         // dependency directory.
-        return array_merge(
-            $this->getSiteDataFiles(),
-            $this->getComposerDataFiles()
-        );
+        return [
+            ...$this->getSiteDataFiles(),
+            ...$this->getComposerDataFiles(),
+        ];
     }
 
     protected function getWwwPath(): string
@@ -70,10 +70,10 @@ class SiteConcentrateFileFinder implements Concentrate_DataProvider_FileFinderIn
                             'dependencies'
                         );
 
-                        $files = array_merge(
-                            $files,
-                            $finder->getDataFiles()
-                        );
+                        $files = [
+                            ...$files,
+                            ...$finder->getDataFiles(),
+                        ];
                         $package_name = $vendor_dir->read();
                     }
                 }

--- a/Site/SiteConcentrateFileFinder.php
+++ b/Site/SiteConcentrateFileFinder.php
@@ -16,7 +16,7 @@ class SiteConcentrateFileFinder implements Concentrate_DataProvider_FileFinderIn
         );
     }
 
-    protected function getWwwPath()
+    protected function getWwwPath(): string
     {
         $www_path = realpath('.');
 
@@ -27,12 +27,15 @@ class SiteConcentrateFileFinder implements Concentrate_DataProvider_FileFinderIn
         return $www_path;
     }
 
-    protected function getRootPath()
+    protected function getRootPath(): string
     {
         return dirname($this->getWwwPath());
     }
 
-    protected function getComposerDataFiles()
+    /**
+     * @return string[]
+     */
+    protected function getComposerDataFiles(): array
     {
         $files = [];
 
@@ -82,7 +85,10 @@ class SiteConcentrateFileFinder implements Concentrate_DataProvider_FileFinderIn
         return $files;
     }
 
-    protected function getSiteDataFiles()
+    /**
+     * @return string[]
+     */
+    protected function getSiteDataFiles(): array
     {
         $files = [];
 

--- a/Site/SiteConcentrateFileFinder.php
+++ b/Site/SiteConcentrateFileFinder.php
@@ -39,8 +39,7 @@ class SiteConcentrateFileFinder implements Concentrate_DataProvider_FileFinderIn
     {
         $files = [];
 
-        $www_path = $this->getWwwPath();
-        $base_path = dirname($www_path) . DIRECTORY_SEPARATOR . 'vendor';
+        $base_path = $this->getRootPath() . DIRECTORY_SEPARATOR . 'vendor';
         if (is_dir($base_path)) {
             $base_dir = dir($base_path);
             $vendor_name = $base_dir->read();

--- a/Site/SiteConcentrateFileFinder.php
+++ b/Site/SiteConcentrateFileFinder.php
@@ -16,20 +16,9 @@ class SiteConcentrateFileFinder implements Concentrate_DataProvider_FileFinderIn
         ];
     }
 
-    protected function getWwwPath(): string
-    {
-        $www_path = realpath('.');
-
-        while (basename($www_path) !== 'www') {
-            $www_path = dirname($www_path);
-        }
-
-        return $www_path;
-    }
-
     protected function getRootPath(): string
     {
-        return dirname($this->getWwwPath());
+        return dirname(__DIR__, 3);
     }
 
     /**


### PR DESCRIPTION
Prevents an infinite loop when we try to output CSS dependencies from a CLI script.