### PR TITLE
Add enum handling

### DIFF
--- a/Site/Site.php
+++ b/Site/Site.php
@@ -3,7 +3,7 @@
 /**
  * Container for package wide static methods.
  *
- * @copyright 2005-2020 silverorange
+ * @copyright 2005-2025 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class Site
@@ -313,6 +313,8 @@ class Site
             // Sentry error logging
             'sentry.dsn'         => null,
             'sentry.environment' => null,
+            // SwatDB enum mapping
+            'swatdb.enum_mapping' => [],
         ];
     }
 

--- a/Site/SiteDatabaseModule.php
+++ b/Site/SiteDatabaseModule.php
@@ -26,7 +26,7 @@ class SiteDatabaseModule extends SiteApplicationModule
     /**
      * The database connection object.
      *
-     * @var MDB2_Connection
+     * @var MDB2_Driver_Common
      *
      * @see SiteDatabaseModule::getConnection()
      */
@@ -34,7 +34,7 @@ class SiteDatabaseModule extends SiteApplicationModule
 
     public function init()
     {
-        $this->connection = MDB2::connect($this->dsn);
+        $this->connection = SwatDB::connect($this->dsn);
 
         if (MDB2::isError($this->connection)) {
             throw new SwatDBException($this->connection);
@@ -43,6 +43,9 @@ class SiteDatabaseModule extends SiteApplicationModule
         $this->connection->options['portability'] =
             $this->connection->options['portability'] ^
                 MDB2_PORTABILITY_EMPTY_TO_NULL;
+
+
+        $this->setupEnumMapping();
 
         // Set up convenience reference
         $this->app->db = $this->getConnection();
@@ -56,5 +59,11 @@ class SiteDatabaseModule extends SiteApplicationModule
     public function getConnection()
     {
         return $this->connection;
+    }
+
+    protected function setupEnumMapping()
+    {
+        $config = $this->app->getModule('SiteConfigModule');
+        dd($config);
     }
 }

--- a/Site/SiteDatabaseModule.php
+++ b/Site/SiteDatabaseModule.php
@@ -8,7 +8,7 @@
  * you may make database calls using <code>$app->db</code> instead of
  * <code>$app->database->getConnection()</code>.
  *
- * @copyright 2005-2016 silverorange
+ * @copyright 2005-2025 silverorange
  */
 class SiteDatabaseModule extends SiteApplicationModule
 {
@@ -44,7 +44,6 @@ class SiteDatabaseModule extends SiteApplicationModule
             $this->connection->options['portability'] ^
                 MDB2_PORTABILITY_EMPTY_TO_NULL;
 
-
         $this->setupEnumMapping();
 
         // Set up convenience reference
@@ -54,16 +53,29 @@ class SiteDatabaseModule extends SiteApplicationModule
     /**
      * Retrieves the MDB2 connection object.
      *
-     * @return MDB2_Connection the MDB2 connection object of this module
+     * @return MDB2_Driver_Common the MDB2 connection object of this module
      */
     public function getConnection()
     {
         return $this->connection;
     }
 
+    /**
+     * Configures any enum mapping for SwatDB objects.
+     */
     protected function setupEnumMapping()
     {
+        if (!$this->app->hasModule('SiteConfigModule')) {
+            return;
+        }
+
         $config = $this->app->getModule('SiteConfigModule');
-        dd($config);
+        $enum_mapping = $config->swatdb->enum_mapping ?? [];
+
+        if (count($enum_mapping) === 0) {
+            return;
+        }
+
+        SwatDBEnumMapper::initialize($this->connection, $enum_mapping);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
 		"sentry/sentry": "^4.9",
 		"silverorange/concentrate": "^2.0.0",
 		"silverorange/mdb2": "^3.0.0",
-		"silverorange/swat": "^7.1.0",
+		"silverorange/swat": "^7.9.0",
 		"silverorange/xml_rpc2": "^2.0",
 		"silverorange/xml_rpc_ajax": "^3.1",
 		"symfony/mailer": "^5.4"


### PR DESCRIPTION
This PR sets up automatic enum handling for `SwatDBDataObject`s if the configuration file has those mappings defined.

This ties in with https://github.com/silverorange/swat/pull/169 which adds that feature to Swat, so the package version requirement is bumped.

To configure the application to do automatic mapping, create the relevant entries in the application config file (e.g. `emrap.ini` for EM:RAP):

```ini
[swatdb]
enum_mapping[group_subscription_type] = "GroupSubscriptionType"
```

The configuration **key** (i.e. the string inside the `[...]`) represents the name of the database type.  In this example, this would be taken from:

```sql
CREATE TYPE subscription_type AS ENUM ('RENEWAL', 'ADDITION', 'NEW_GROUP');
```

The configuration **value** (i.e. the string inside the `"..."` after the equals sign) is the fully-qualified PHP class name for the enum to which you wish to map that field type.  For example:

```php
enum SubscriptionType {
    case RENEWAL;
    case ADDITION;
    case NEW_GROUP;
}
```

The case **names** in the PHP enum class need to exactly match the possible values defined in the SQL type.

The above is an example of a basic unit enum.  [Backed enums](https://www.php.net/manual/en/language.enumerations.backed.php) can also be used, in which case the enum case **values** need to match, e.g.:

```php
enum SubscriptionType: string {
    case foo = 'RENEWAL';
    case bar = 'ADDITION';
    case qua = 'NEW_GROUP';
}
```

See https://github.com/silverorange/swat/pull/169 for details on how to then set up your SwatDBDataObjects.