### PR TITLE
Allow env vars to override config values from ini files and default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ yarn.lock
 
 # overrides for local tooling
 /phpstan.neon
+
+# tests
+.phpunit.cache/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,5 +19,11 @@ pipeline {
                 sh 'composer run phpstan:ci'
             }
         }
+
+        stage('Run unit tests') {
+            steps {
+                sh 'composer run test'
+            }
+        }
     }
 }

--- a/Site/SiteConfigModule.php
+++ b/Site/SiteConfigModule.php
@@ -40,7 +40,17 @@
  * tagline = Supercool
  * </pre>
  *
- * <strong>2. ConfigSetting Table:</strong>
+ * <strong>2. environment variables:</strong>
+ *
+ * Environment variables may be set to override values from an ini file, or
+ * to provide values that are omitted from an ini file. Variables are uppercase
+ * in the form `SECTION_NAME_VALUE_NAME`
+ *
+ * <pre>
+ * SITE_TITLE="My Cool Website" SITE_TAGLINE="Supercool" php index.php
+ * </pre>
+ *
+ * <strong>3. ConfigSetting Table:</strong>
  *
  * If the application has a database and a table named <em>ConfigSetting</em>
  * exists, settings are loaded from the table. The column <code>name</code>
@@ -61,7 +71,7 @@
  * +--------------+-----------------+
  * </pre>
  *
- * <strong>3. InstanceConfigSetting Table:</strong>
+ * <strong>4. InstanceConfigSetting Table:</strong>
  *
  * If the application uses site instances, settings are loaded from the
  * <em>InstanceConfigSetting</em> table. The format is the same as the
@@ -89,9 +99,9 @@
  * database. File-based saving is intentionally excluded.
  *
  * Setting values are only saved if they are set during runtime and are
- * different than the loaded value.
+ * different from the loaded value.
  *
- * @copyright 2006-2016 silverorange
+ * @copyright 2006-2026 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SiteConfigModule extends SiteApplicationModule
@@ -123,38 +133,34 @@ class SiteConfigModule extends SiteApplicationModule
     public const SOURCE_RUNTIME = 5;
 
     /**
+     * Value was set from environment.
+     */
+    public const SOURCE_ENV = 6;
+
+    /**
      * The sections of this configuration.
      *
      * This array is indexed by section names and contains SiteConfigSection
      * objects as parsed from the ini file.
      *
-     * @var array
+     * @var array<string,SiteConfigSection>
      */
-    private $sections = [];
+    private array $sections = [];
 
     /**
-     * Whether or not this config module has been loaded.
-     *
-     * @var bool
+     * Whether this config module has been loaded.
      */
-    private $loaded = false;
+    private bool $loaded = false;
 
     /**
      * Configuration setting definitions of this config module.
      *
-     * @var array
-     *
      * @see SiteConfigModule::addDefinition()
      * @see SiteConfigModule::addDefinitions()
-     */
-    private $definitions = [];
-
-    /**
-     * The path to the .ini of this config module.
      *
-     * @var string
+     * @var array<string,array<string,mixed>>
      */
-    private $config_filename;
+    private array $definitions = [];
 
     /**
      * Data sources for current config settings.
@@ -162,18 +168,18 @@ class SiteConfigModule extends SiteApplicationModule
      * The array is of the form:
      * <code>
      * <?php
-     * array(
-     *    'mysection' => array(
+     * [
+     *    'mysection' => [
      *        'mysetting' => 1,
      *        'mysetting' => 2,
-     *    ),
-     * );
+     *    ],
+     * ];
      * ?>
      * </code>
      *
-     * @var array
+     * @var array<string,array<string,int>>
      */
-    private $setting_sources = [];
+    private array $setting_sources = [];
 
     /**
      * Initializes this module.
@@ -198,10 +204,9 @@ class SiteConfigModule extends SiteApplicationModule
      *
      * @param string $filename the filename of the ini file to load
      */
-    public function load($filename)
+    public function load(string $filename): void
     {
-        $this->config_filename = $filename;
-        $this->loadFileValues();
+        $this->loadFileValues($filename);
 
         // create default sections with default values
         foreach ($this->definitions as $section_name => $default_values) {
@@ -214,6 +219,8 @@ class SiteConfigModule extends SiteApplicationModule
                 );
             }
         }
+
+        $this->loadEnvValues();
 
         $this->loaded = true;
     }
@@ -251,23 +258,24 @@ class SiteConfigModule extends SiteApplicationModule
      * Only defined settings are be loaded from an ini file. Other settings in
      * ini files are ignored.
      *
-     * @param array $definitions an associative array of setting definitions.
-     *                           The array is of the form:
-     *                           qualified_name => default_value where
-     *                           qualified_name is a string containing the
-     *                           section name and the setting name separated
-     *                           by a '.'. For example, a setting for 'dsn' in
-     *                           the 'database' section would have a qualified
-     *                           name of 'database.dsn'. The default value is
-     *                           a string containing the value to use for the
-     *                           setting if the setting does not exist in the
-     *                           loaded configuration file. Use null to
-     *                           specify no default.
+     * @param array<string,mixed> $definitions an associative array of setting
+     *                                         definitions.
+     *                                         The array is of the form:
+     *                                         qualified_name => default_value where
+     *                                         qualified_name is a string containing the
+     *                                         section name and the setting name separated
+     *                                         by a '.'. For example, a setting for 'dsn' in
+     *                                         the 'database' section would have a qualified
+     *                                         name of 'database.dsn'. The default value is
+     *                                         a string containing the value to use for the
+     *                                         setting if the setting does not exist in the
+     *                                         loaded configuration file. Use null to
+     *                                         specify no default.
      *
      * @throws SiteException if the qualified name does not contain a section
      *                       and a setting name
      */
-    public function addDefinitions(array $definitions)
+    public function addDefinitions(array $definitions): void
     {
         foreach ($definitions as $qualified_name => $default_value) {
             if (mb_strpos($qualified_name, '.') === false) {
@@ -300,11 +308,11 @@ class SiteConfigModule extends SiteApplicationModule
      * @throws SiteException if the name is not a valid name. Valid names follow
      *                       the rules for PHP identifiers.
      */
-    public function addDefinition($section, $name, $default_value = null)
-    {
-        $section = (string) $section;
-        $name = (string) $name;
-
+    public function addDefinition(
+        string $section,
+        string $name,
+        mixed $default_value = null
+    ): void {
         if (!$this->isValidKey($section)) {
             throw new SiteException(sprintf(
                 "Section '%s' in configuration definition is not a valid name.",
@@ -380,8 +388,7 @@ class SiteConfigModule extends SiteApplicationModule
      * Gets the source of a config setting value.
      *
      * @param string $section the config setting section
-     * @param string $section the config setting name
-     * @param mixed  $name
+     * @param string $name    the config setting name
      *
      * @return int either {@link SiteConfigModule::SOURCE_DEFAULT},
      *             {@link SiteConfigModule::SOURCE_FILE},
@@ -392,7 +399,7 @@ class SiteConfigModule extends SiteApplicationModule
      * @throws SiteException if there is no config setting defined for the
      *                       given section and name
      */
-    public function getSource($section, $name)
+    public function getSource(string $section, string $name): int
     {
         if (!array_key_exists($section, $this->setting_sources)) {
             throw new SiteException(sprintf(
@@ -418,7 +425,7 @@ class SiteConfigModule extends SiteApplicationModule
      * Sets the source of a config setting value.
      *
      * @param string $section the config setting section
-     * @param string $section the config setting name
+     * @param string $name    the config setting name
      * @param int    $source  either {@link SiteConfigModule::SOURCE_DEFAULT},
      *                        {@link SiteConfigModule::SOURCE_FILE},
      *                        {@link SiteConfigModule::SOURCE_DATABASE},
@@ -429,7 +436,7 @@ class SiteConfigModule extends SiteApplicationModule
      * @throws SiteException if there is no config setting defined for the
      *                       given section and name
      */
-    public function setSource($section, $name, $source)
+    public function setSource(string $section, string $name, int $source): void
     {
         if (!array_key_exists($section, $this->setting_sources)) {
             throw new SiteException(sprintf(
@@ -437,8 +444,6 @@ class SiteConfigModule extends SiteApplicationModule
                 $name
             ));
         }
-
-        $setting_names = $this->setting_sources[$section];
 
         if (!array_key_exists($name, $this->setting_sources[$section])) {
             throw new SiteException(sprintf(
@@ -448,7 +453,14 @@ class SiteConfigModule extends SiteApplicationModule
             ));
         }
 
-        $valid_sources = [self::SOURCE_DEFAULT, self::SOURCE_FILE, self::SOURCE_DATABASE, self::SOURCE_INSTANCE, self::SOURCE_RUNTIME];
+        $valid_sources = [
+            self::SOURCE_DEFAULT,
+            self::SOURCE_FILE,
+            self::SOURCE_DATABASE,
+            self::SOURCE_INSTANCE,
+            self::SOURCE_RUNTIME,
+            self::SOURCE_ENV,
+        ];
 
         if (!in_array($source, $valid_sources)) {
             $source = self::SOURCE_RUNTIME;
@@ -464,7 +476,7 @@ class SiteConfigModule extends SiteApplicationModule
      *
      * @return SiteConfigSection the config section
      */
-    public function __get($name)
+    public function __get(string $name): SiteConfigSection
     {
         if (!array_key_exists($name, $this->sections)) {
             throw new SiteException(sprintf(
@@ -484,7 +496,7 @@ class SiteConfigModule extends SiteApplicationModule
      * @return bool true if the section exists in this config module and
      *              false if it does not
      */
-    public function __isset($name)
+    public function __isset(string $name): bool
     {
         return array_key_exists($name, $this->sections);
     }
@@ -508,15 +520,21 @@ class SiteConfigModule extends SiteApplicationModule
 
     /**
      * Loads config setting values from the ini file.
+     *
+     * @param string $filename the filename of the ini file to load
      */
-    protected function loadFileValues()
+    protected function loadFileValues(string $filename): void
     {
-        $ini_array = parse_ini_file($this->config_filename, true);
+        $ini_array = parse_ini_file($filename, true);
         foreach ($ini_array as $section_name => $section_values) {
+            // coerce all keys to strings
+            $section_name = (string) $section_name;
             if (array_key_exists($section_name, $this->definitions)) {
                 // only include values that are defined
                 $defined_section_values = [];
                 foreach ($section_values as $name => $value) {
+                    // coerce all keys to strings
+                    $name = (string) $name;
                     if (array_key_exists(
                         $name,
                         $this->definitions[$section_name]
@@ -542,12 +560,14 @@ class SiteConfigModule extends SiteApplicationModule
         }
     }
 
+    protected function loadEnvValues(): void {}
+
     /**
      * Loads config setting values from the database.
      *
      * Setting values are loaded from the <em>ConfigSetting</em> table.
      */
-    protected function loadDatabaseValues()
+    protected function loadDatabaseValues(): void
     {
         // if there is no database module, do nothing
         if (!$this->app->hasModule('SiteDatabaseModule')) {
@@ -596,7 +616,7 @@ class SiteConfigModule extends SiteApplicationModule
      *
      * Setting values are loaded from the <em>InstanceConfigSetting</em> table.
      */
-    protected function loadInstanceValues()
+    protected function loadInstanceValues(): void
     {
         $instance = $this->app->getInstance();
 
@@ -656,7 +676,7 @@ class SiteConfigModule extends SiteApplicationModule
             foreach ($settings as $setting) {
                 $sql = sprintf(
                     'delete from ConfigSetting
-					where name = %s',
+                    where name = %s',
                     $db->quote($setting, 'text')
                 );
 
@@ -666,7 +686,7 @@ class SiteConfigModule extends SiteApplicationModule
                 if ($this->{$section}->{$name} != '') {
                     $sql = sprintf(
                         'insert into ConfigSetting
-						(name, value) values (%s, %s)',
+                        (name, value) values (%s, %s)',
                         $db->quote($setting, 'text'),
                         $db->quote($this->{$section}->{$name}, 'text')
                     );
@@ -703,7 +723,7 @@ class SiteConfigModule extends SiteApplicationModule
             foreach ($settings as $setting) {
                 $sql = sprintf(
                     'delete from InstanceConfigSetting
-					where instance = %s and name = %s and is_default = %s',
+                    where instance = %s and name = %s and is_default = %s',
                     $db->quote($instance, 'integer'),
                     $db->quote($setting, 'text'),
                     $db->quote(false, 'boolean')
@@ -715,7 +735,7 @@ class SiteConfigModule extends SiteApplicationModule
                 if ($this->{$section}->{$name} != '') {
                     $sql = sprintf(
                         'insert into InstanceConfigSetting
-						(name, value, instance) values (%s, %s, %s)',
+                        (name, value, instance) values (%s, %s, %s)',
                         $db->quote($setting, 'text'),
                         $db->quote($this->{$section}->{$name}, 'text'),
                         $db->quote($instance, 'integer')
@@ -734,16 +754,16 @@ class SiteConfigModule extends SiteApplicationModule
     }
 
     /**
-     * Checks whether or not a name is a valid section name or setting name.
+     * Checks whether a name is a valid section name or setting name.
      *
      * @param string $name the name to check
      *
      * @return bool true if the name is valid and false if it is not
      */
-    private function isValidKey($name)
+    private function isValidKey(string $name): bool
     {
         $regexp = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/';
 
-        return preg_match($regexp, $name) == 1;
+        return preg_match($regexp, $name) === 1;
     }
 }

--- a/Site/SiteConfigModule.php
+++ b/Site/SiteConfigModule.php
@@ -177,7 +177,7 @@ class SiteConfigModule extends SiteApplicationModule
      * ?>
      * </code>
      *
-     * @var array<string,array<string,int>>
+     * @var array<string,array<string,self::SOURCE_*>>
      */
     private array $setting_sources = [];
 
@@ -236,9 +236,10 @@ class SiteConfigModule extends SiteApplicationModule
      * If there is no database module, the settings values of this config
      * module can not be saved.
      *
-     * @param array $settings an array of config settings to save
+     * @param string[] $settings an array of qualified names of config
+     *                           settings to save
      */
-    public function save(array $settings)
+    public function save(array $settings): void
     {
         // if there is no database module, do nothing
         if (!$this->app->hasModule('SiteDatabaseModule')) {
@@ -299,7 +300,7 @@ class SiteConfigModule extends SiteApplicationModule
      *
      * @param string $section       the section the setting belongs to
      * @param string $name          the name of the setting
-     * @param string $default_value optional. The default value of the setting.
+     * @param mixed  $default_value optional. The default value of the setting.
      *                              Used if the setting does exist in the
      *                              loaded ini file.
      *
@@ -390,11 +391,7 @@ class SiteConfigModule extends SiteApplicationModule
      * @param string $section the config setting section
      * @param string $name    the config setting name
      *
-     * @return int either {@link SiteConfigModule::SOURCE_DEFAULT},
-     *             {@link SiteConfigModule::SOURCE_FILE},
-     *             {@link SiteConfigModule::SOURCE_DATABASE},
-     *             {@link SiteConfigModule::SOURCE_INSTANCE} or
-     *             {@link SiteConfigModule::SOURCE_RUNTIME}
+     * @return self::SOURCE_*
      *
      * @throws SiteException if there is no config setting defined for the
      *                       given section and name
@@ -424,14 +421,9 @@ class SiteConfigModule extends SiteApplicationModule
     /**
      * Sets the source of a config setting value.
      *
-     * @param string $section the config setting section
-     * @param string $name    the config setting name
-     * @param int    $source  either {@link SiteConfigModule::SOURCE_DEFAULT},
-     *                        {@link SiteConfigModule::SOURCE_FILE},
-     *                        {@link SiteConfigModule::SOURCE_DATABASE},
-     *                        {@link SiteConfigModule::SOURCE_INSTANCE} or
-     *                        {@link SiteConfigModule::SOURCE_RUNTIME}
-     * @param mixed  $name
+     * @param string         $section the config setting section
+     * @param string         $name    the config setting name
+     * @param self::SOURCE_* $source
      *
      * @throws SiteException if there is no config setting defined for the
      *                       given section and name
@@ -658,9 +650,10 @@ class SiteConfigModule extends SiteApplicationModule
      *
      * Values are saved in the <em>ConfigSetting</em> table.
      *
-     * @param array $settings an array of config settings to save
+     * @param string[] $settings an array of qualified names of config
+     *                           settings to save
      */
-    protected function saveDatabaseValues(array $settings)
+    protected function saveDatabaseValues(array $settings): void
     {
         // if there is no database module, do nothing
         if (!$this->app->hasModule('SiteDatabaseModule')) {
@@ -708,9 +701,10 @@ class SiteConfigModule extends SiteApplicationModule
      * Values are saved in the <em>InstanceConfigSetting</em> table with a
      * binding to the current site instance.
      *
-     * @param array $settings an array of config settings to save
+     * @param string[] $settings an array of qualified names of config
+     *                           settings to save
      */
-    protected function saveInstanceValues(array $settings)
+    protected function saveInstanceValues(array $settings): void
     {
         $instance = $this->app->instance->getId();
 

--- a/Site/SiteConfigModule.php
+++ b/Site/SiteConfigModule.php
@@ -552,6 +552,10 @@ class SiteConfigModule extends SiteApplicationModule
         }
     }
 
+    /**
+     * @throws SiteException when trying to override a config value that is
+     *                       non-scalar and non-null
+     */
     protected function loadEnvValues(): void
     {
         $env = getenv();
@@ -563,6 +567,20 @@ class SiteConfigModule extends SiteApplicationModule
                 );
 
                 if (array_key_exists($env_var_name, $env)) {
+                    $default_value =
+                        $this->definitions[$section_name][$value_name] ?? null;
+
+                    if (!is_scalar($default_value) && !is_null($default_value)) {
+                        $default_type = gettype($default_value);
+
+                        throw new SiteException(
+                            'Environment variables can only override scalar '
+                            . 'or null config values. Defined config for '
+                            . "\"{$section_name}.{$value_name}\" "
+                            . "is {$default_type}."
+                        );
+                    }
+
                     $this->{$section_name}->{$value_name} = $env[$env_var_name];
                     $this->setting_sources[$section_name][$value_name]
                         = self::SOURCE_ENV;

--- a/Site/SiteConfigModule.php
+++ b/Site/SiteConfigModule.php
@@ -40,7 +40,7 @@
  * tagline = Supercool
  * </pre>
  *
- * <strong>2. environment variables:</strong>
+ * <strong>2. Environment Variables:</strong>
  *
  * Environment variables may be set to override values from an ini file, or
  * to provide values that are omitted from an ini file. Variables are uppercase

--- a/Site/SiteConfigModule.php
+++ b/Site/SiteConfigModule.php
@@ -44,10 +44,11 @@
  *
  * Environment variables may be set to override values from an ini file, or
  * to provide values that are omitted from an ini file. Variables are uppercase
- * in the form `SECTION_NAME_VALUE_NAME`
+ * in the form `SECTION_NAME__VALUE_NAME`. Section names are separated from
+ * value names using double underscores.
  *
  * <pre>
- * SITE_TITLE="My Cool Website" SITE_TAGLINE="Supercool" php index.php
+ * SITE__TITLE="My Cool Website" SITE__TAGLINE="Supercool" php index.php
  * </pre>
  *
  * <strong>3. ConfigSetting Table:</strong>
@@ -563,7 +564,7 @@ class SiteConfigModule extends SiteApplicationModule
         foreach ($this->sections as $section_name => $section) {
             foreach ($section as $value_name => $value) {
                 $env_var_name = mb_strtoupper(
-                    $section_name . '_' . $value_name
+                    $section_name . '__' . $value_name
                 );
 
                 if (array_key_exists($env_var_name, $env)) {

--- a/Site/SiteConfigModule.php
+++ b/Site/SiteConfigModule.php
@@ -552,7 +552,24 @@ class SiteConfigModule extends SiteApplicationModule
         }
     }
 
-    protected function loadEnvValues(): void {}
+    protected function loadEnvValues(): void
+    {
+        $env = getenv();
+
+        foreach ($this->sections as $section_name => $section) {
+            foreach ($section as $value_name => $value) {
+                $env_var_name = mb_strtoupper(
+                    $section_name . '_' . $value_name
+                );
+
+                if (array_key_exists($env_var_name, $env)) {
+                    $this->{$section_name}->{$value_name} = $env[$env_var_name];
+                    $this->setting_sources[$section_name][$value_name]
+                        = self::SOURCE_ENV;
+                }
+            }
+        }
+    }
 
     /**
      * Loads config setting values from the database.

--- a/Site/SiteConfigSection.php
+++ b/Site/SiteConfigSection.php
@@ -103,9 +103,9 @@ class SiteConfigSection extends SwatObject implements Iterator
     /**
      * Returns the key of the current value.
      *
-     * @return int the key of the current value
+     * @return string the key of the current value
      */
-    public function key(): int
+    public function key(): string
     {
         return key($this->values);
     }

--- a/Site/SiteConfigSection.php
+++ b/Site/SiteConfigSection.php
@@ -3,47 +3,47 @@
 /**
  * Configuration section for the configuration module.
  *
- * @copyright 2007-2016 silverorange
+ * @copyright 2007-2026 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class SiteConfigSection extends SwatObject implements Iterator
 {
     /**
      * The name of this configuration section.
-     *
-     * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * Settings of this configuration section.
+     *
+     * @var array<string,mixed>
      */
-    private $values = [];
+    private array $values = [];
 
     /**
      * The config module of this section.
-     *
-     * @var SiteConfigModule
      */
-    private $config;
+    private SiteConfigModule $config;
 
     /**
      * Creates a new configuration section.
      *
-     * @param string           $name   the name of this configuration section
-     * @param array            $values an associative array containing values as parsed
-     *                                 from an ini file
-     * @param SiteConfigModule $config the config module of this section
-     * @param int              $source optional. The setting source of the
-     *                                 <code>$values</code> array.
+     * @param string              $name   the name of this configuration section
+     * @param array<string,mixed> $values an associative array
+     *                                    containing
+     *                                    values as parsed
+     *                                    from an ini file
+     * @param SiteConfigModule    $config the config module of this section
+     * @param int                 $source optional. The setting source of the
+     *                                    <code>$values</code> array.
      */
     public function __construct(
-        $name,
+        string $name,
         array $values,
         SiteConfigModule $config,
-        $source = SiteConfigModule::SOURCE_FILE
+        int $source = SiteConfigModule::SOURCE_FILE
     ) {
-        $this->name = (string) $name;
+        $this->name = $name;
         $this->values = $values;
         $this->config = $config;
 
@@ -65,7 +65,7 @@ class SiteConfigSection extends SwatObject implements Iterator
         ob_start();
 
         $is_empty = true;
-        foreach ($this->values as $name => $value) {
+        foreach ($this->values as $value) {
             if ($value !== null) {
                 $is_empty = false;
             }
@@ -146,7 +146,7 @@ class SiteConfigSection extends SwatObject implements Iterator
      * @throws SiteException if the name of the setting being set does not
      *                       exist in this section
      */
-    public function __set($name, $value)
+    public function __set(string $name, mixed $value): void
     {
         if (!array_key_exists($name, $this->values)) {
             throw new SiteException(
@@ -178,7 +178,7 @@ class SiteConfigSection extends SwatObject implements Iterator
      * @throws SiteException if the setting being set does not exist in this
      *                       section
      */
-    public function __get($name)
+    public function __get(string $name): mixed
     {
         if (!array_key_exists($name, $this->values)) {
             throw new SiteException(
@@ -202,7 +202,7 @@ class SiteConfigSection extends SwatObject implements Iterator
      * @return bool true if the configuration setting exists and false if it
      *              does not
      */
-    public function __isset($name)
+    public function __isset(string $name): bool
     {
         return isset($this->values[$name]);
     }

--- a/Site/SiteConfigSection.php
+++ b/Site/SiteConfigSection.php
@@ -28,14 +28,15 @@ class SiteConfigSection extends SwatObject implements Iterator
     /**
      * Creates a new configuration section.
      *
-     * @param string              $name   the name of this configuration section
-     * @param array<string,mixed> $values an associative array
-     *                                    containing
-     *                                    values as parsed
-     *                                    from an ini file
-     * @param SiteConfigModule    $config the config module of this section
-     * @param int                 $source optional. The setting source of the
-     *                                    <code>$values</code> array.
+     * @param string                     $name   the name of this configuration section
+     * @param array<string,mixed>        $values an associative array
+     *                                           containing
+     *                                           values as parsed
+     *                                           from an ini file
+     * @param SiteConfigModule           $config the config module of this section
+     * @param SiteConfigModule::SOURCE_* $source optional. The setting
+     *                                           source of the
+     *                                           <code>$values</code> array.
      */
     public function __construct(
         string $name,

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,10 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "3.64.0",
+    "mockery/mockery": "^1.6",
     "phpstan/phpstan": "^1.12",
+    "phpstan/phpstan-mockery": "^1.1",
+    "phpunit/phpunit": "^10.5",
     "rector/rector": "^1.2"
   },
   "suggest": {
@@ -86,11 +89,13 @@
     "phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
     "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline",
     "rector": "./vendor/bin/rector --dry-run",
-    "rector:fix": "./vendor/bin/rector"
+    "rector:fix": "./vendor/bin/rector",
+    "test": "phpunit"
   },
   "autoload": {
     "classmap": [
-      "Site/"
+      "Site/",
+      "tests/Site/"
     ]
   },
   "config": {

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,4 +1,5 @@
 includes:
+  - vendor/phpstan/phpstan-mockery/extension.neon
   - phpstan-baseline.neon
 
 parameters:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  bootstrap="tests/bootstrap.php"
+  cacheDirectory=".phpunit.cache"
+  colors="true"
+  defaultTestSuite="unit"
+  displayDetailsOnTestsThatTriggerWarnings="true"
+  executionOrder="depends,defects"
+  beStrictAboutCoverageMetadata="true"
+  beStrictAboutOutputDuringTests="true"
+  failOnRisky="true"
+  failOnWarning="true"
+>
+  <testsuites>
+    <testsuite name="unit">
+      <directory>tests/Site</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/Site/SiteConfigModuleTest.php
+++ b/tests/Site/SiteConfigModuleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -19,6 +20,12 @@ class SiteConfigModuleTest extends TestCase
     /** @var string[] */
     private array $temp_ini_files = [];
 
+    /** @var string[] */
+    private array $modified_env_vars = [];
+
+    /** @var array<string,string> */
+    private array $original_env = [];
+
     #[Test]
     public function usesDefaultsWhenConfigFileIsEmpty(): void
     {
@@ -29,14 +36,14 @@ class SiteConfigModuleTest extends TestCase
             'account.persistent_login_time'    => 2419200,
             'account.persistent_login_enabled' => false,
             'site.meta_description'            => null,
-            'site.title'                       => 'default title',
+            'site.title'                       => 'Default title',
         ]);
         $module->load($this->getTempIniFile(''));
 
         self::assertEquals(2419200, $module->account->persistent_login_time);
         self::assertFalse($module->account->persistent_login_enabled);
         self::assertEquals(null, $module->site->meta_description);
-        self::assertEquals('default title', $module->site->title);
+        self::assertEquals('Default title', $module->site->title);
     }
 
     #[Test]
@@ -49,34 +56,83 @@ class SiteConfigModuleTest extends TestCase
             'account.persistent_login_time'    => 2419200,
             'account.persistent_login_enabled' => false,
             'site.meta_description'            => null,
-            'site.title'                       => 'default title',
+            'site.title'                       => 'Default title',
         ]);
         $module->load($this->getTempIniFile(
             <<<'INI'
                 [account]
-                persistent_login_time = 123456;
-                persistent_login_enabled = On;
+                persistent_login_time = 123456
+                persistent_login_enabled = On
 
                 [site]
-                meta_description = "Meta description";
-                title = "Title";
+                meta_description = "Ini meta description"
+                title = "Ini title"
                 INI
         ));
 
         self::assertEquals(123456, $module->account->persistent_login_time);
         self::assertEquals('1', $module->account->persistent_login_enabled);
-        self::assertEquals('Meta description', $module->site->meta_description);
-        self::assertEquals('Title', $module->site->title);
+        self::assertEquals(
+            'Ini meta description',
+            $module->site->meta_description
+        );
+        self::assertEquals('Ini title', $module->site->title);
+    }
+
+    #[Test]
+    public function overridesConfigUsingEnvVars(): void
+    {
+        $app = Mockery::mock(SiteApplication::class);
+
+        $module = new SiteConfigModule($app);
+        $module->addDefinitions([
+            'site.title' => 'Default title',
+        ]);
+        $this->setEnvVar('SITE_TITLE', 'Environment title');
+        $module->load($this->getTempIniFile(
+            <<<'INI'
+                [site]
+                title = "Title"
+                INI
+        ));
+
+        self::assertEquals('Environment title', $module->site->title);
     }
 
     #[After]
     public function cleanUpTempFiles(): void
     {
         foreach ($this->temp_ini_files as $filename) {
-            unlink($filename);
+            if (file_exists($filename)) {
+                unlink($filename);
+            }
         }
 
         $this->temp_ini_files = [];
+    }
+
+    #[Before]
+    public function setOriginalEnv(): void
+    {
+        $this->original_env = getenv() ?: [];
+    }
+
+    #[After]
+    public function cleanUpEnvVars(): void
+    {
+        foreach ($this->modified_env_vars as $name) {
+            if (array_key_exists($name, $this->original_env)) {
+                putenv("{$name}={$this->original_env[$name]}");
+            } else {
+                putenv($name);
+            }
+        }
+    }
+
+    private function setEnvVar(string $name, string $value): void
+    {
+        $this->modified_env_vars[] = $name;
+        putenv("{$name}={$value}");
     }
 
     private function getTempIniFile(string $ini_contents): string

--- a/tests/Site/SiteConfigModuleTest.php
+++ b/tests/Site/SiteConfigModuleTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class SiteConfigModuleTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    #[Test]
+    public function usesDefaultsWhenConfigFileIsEmpty(): void
+    {
+        $app = Mockery::mock(SiteApplication::class);
+
+        $module = new SiteConfigModule($app);
+        $module->addDefinitions([
+            'account.persistent_login_time'    => 2419200,
+            'account.persistent_login_enabled' => false,
+            'account.restore_cookie_enabled'   => false,
+            'site.meta_description'            => null,
+            'site.title'                       => null,
+            'site.resource_tag'                => null,
+            'site.shortname'                   => null,
+        ]);
+        $module->load($config_filename);
+
+        self::assertEquals('test', (string) $module);
+    }
+
+    #[Test]
+    public function loadsConfigValuesFromIni(): void
+    {
+        $app = Mockery::mock(SiteApplication::class);
+
+        $module = new SiteConfigModule($app);
+        $module->addDefinitions([
+            'account.persistent_login_time'    => 2419200,
+            'account.persistent_login_enabled' => false,
+            'account.restore_cookie_enabled'   => false,
+            'site.meta_description'            => null,
+            'site.title'                       => null,
+            'site.resource_tag'                => null,
+            'site.shortname'                   => null,
+        ]);
+        $module->load($config_filename);
+    }
+}

--- a/tests/Site/SiteConfigModuleTest.php
+++ b/tests/Site/SiteConfigModuleTest.php
@@ -118,7 +118,7 @@ class SiteConfigModuleTest extends TestCase
         $module->addDefinitions([
             'site.title' => 'Default title',
         ]);
-        $this->setEnvVar('SITE_TITLE', 'Environment title');
+        $this->setEnvVar('SITE__TITLE', 'Environment title');
         $module->load($this->getTempIniFile(
             <<<'INI'
                 [site]
@@ -144,7 +144,7 @@ class SiteConfigModuleTest extends TestCase
         $module->addDefinitions([
             'site.emails' => ['test@example.com', 'foo@example.com'],
         ]);
-        $this->setEnvVar('SITE_EMAILS', 'bar@example.com');
+        $this->setEnvVar('SITE__EMAILS', 'bar@example.com');
         $module->load($this->getTempIniFile(''));
     }
 

--- a/tests/Site/SiteConfigModuleTest.php
+++ b/tests/Site/SiteConfigModuleTest.php
@@ -40,10 +40,10 @@ class SiteConfigModuleTest extends TestCase
         ]);
         $module->load($this->getTempIniFile(''));
 
-        self::assertEquals(2419200, $module->account->persistent_login_time);
+        self::assertSame(2419200, $module->account->persistent_login_time);
         self::assertFalse($module->account->persistent_login_enabled);
-        self::assertEquals(null, $module->site->meta_description);
-        self::assertEquals('Default title', $module->site->title);
+        self::assertSame(null, $module->site->meta_description);
+        self::assertSame('Default title', $module->site->title);
     }
 
     #[Test]
@@ -70,13 +70,13 @@ class SiteConfigModuleTest extends TestCase
                 INI
         ));
 
-        self::assertEquals(123456, $module->account->persistent_login_time);
-        self::assertEquals('1', $module->account->persistent_login_enabled);
-        self::assertEquals(
+        self::assertSame('123456', $module->account->persistent_login_time);
+        self::assertSame('1', $module->account->persistent_login_enabled);
+        self::assertSame(
             'Ini meta description',
             $module->site->meta_description
         );
-        self::assertEquals('Ini title', $module->site->title);
+        self::assertSame('Ini title', $module->site->title);
     }
 
     #[Test]
@@ -96,7 +96,7 @@ class SiteConfigModuleTest extends TestCase
                 INI
         ));
 
-        self::assertEquals('Environment title', $module->site->title);
+        self::assertSame('Environment title', $module->site->title);
     }
 
     #[Test]

--- a/tests/Site/SiteConfigModuleTest.php
+++ b/tests/Site/SiteConfigModuleTest.php
@@ -26,6 +26,36 @@ class SiteConfigModuleTest extends TestCase
     /** @var array<string,string> */
     private array $original_env = [];
 
+    #[Before]
+    public function setOriginalEnv(): void
+    {
+        $this->original_env = getenv() ?: [];
+    }
+
+    #[After]
+    public function cleanUpEnvVars(): void
+    {
+        foreach ($this->modified_env_vars as $name) {
+            if (array_key_exists($name, $this->original_env)) {
+                putenv("{$name}={$this->original_env[$name]}");
+            } else {
+                putenv($name);
+            }
+        }
+    }
+
+    #[After]
+    public function cleanUpTempFiles(): void
+    {
+        foreach ($this->temp_ini_files as $filename) {
+            if (file_exists($filename)) {
+                unlink($filename);
+            }
+        }
+
+        $this->temp_ini_files = [];
+    }
+
     #[Test]
     public function usesDefaultsWhenConfigFileIsEmpty(): void
     {
@@ -116,36 +146,6 @@ class SiteConfigModuleTest extends TestCase
         ]);
         $this->setEnvVar('SITE_EMAILS', 'bar@example.com');
         $module->load($this->getTempIniFile(''));
-    }
-
-    #[After]
-    public function cleanUpTempFiles(): void
-    {
-        foreach ($this->temp_ini_files as $filename) {
-            if (file_exists($filename)) {
-                unlink($filename);
-            }
-        }
-
-        $this->temp_ini_files = [];
-    }
-
-    #[Before]
-    public function setOriginalEnv(): void
-    {
-        $this->original_env = getenv() ?: [];
-    }
-
-    #[After]
-    public function cleanUpEnvVars(): void
-    {
-        foreach ($this->modified_env_vars as $name) {
-            if (array_key_exists($name, $this->original_env)) {
-                putenv("{$name}={$this->original_env[$name]}");
-            } else {
-                putenv($name);
-            }
-        }
     }
 
     private function setEnvVar(string $name, string $value): void

--- a/tests/Site/SiteConfigModuleTest.php
+++ b/tests/Site/SiteConfigModuleTest.php
@@ -3,17 +3,21 @@
 declare(strict_types=1);
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversClass(SiteConfigModule::class)]
 class SiteConfigModuleTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
+
+    /** @var string[] */
+    private array $temp_ini_files = [];
 
     #[Test]
     public function usesDefaultsWhenConfigFileIsEmpty(): void
@@ -24,15 +28,15 @@ class SiteConfigModuleTest extends TestCase
         $module->addDefinitions([
             'account.persistent_login_time'    => 2419200,
             'account.persistent_login_enabled' => false,
-            'account.restore_cookie_enabled'   => false,
             'site.meta_description'            => null,
-            'site.title'                       => null,
-            'site.resource_tag'                => null,
-            'site.shortname'                   => null,
+            'site.title'                       => 'default title',
         ]);
-        $module->load($config_filename);
+        $module->load($this->getTempIniFile(''));
 
-        self::assertEquals('test', (string) $module);
+        self::assertEquals(2419200, $module->account->persistent_login_time);
+        self::assertFalse($module->account->persistent_login_enabled);
+        self::assertEquals(null, $module->site->meta_description);
+        self::assertEquals('default title', $module->site->title);
     }
 
     #[Test]
@@ -44,12 +48,44 @@ class SiteConfigModuleTest extends TestCase
         $module->addDefinitions([
             'account.persistent_login_time'    => 2419200,
             'account.persistent_login_enabled' => false,
-            'account.restore_cookie_enabled'   => false,
             'site.meta_description'            => null,
-            'site.title'                       => null,
-            'site.resource_tag'                => null,
-            'site.shortname'                   => null,
+            'site.title'                       => 'default title',
         ]);
-        $module->load($config_filename);
+        $module->load($this->getTempIniFile(
+            <<<'INI'
+                [account]
+                persistent_login_time = 123456;
+                persistent_login_enabled = On;
+
+                [site]
+                meta_description = "Meta description";
+                title = "Title";
+                INI
+        ));
+
+        self::assertEquals(123456, $module->account->persistent_login_time);
+        self::assertEquals('1', $module->account->persistent_login_enabled);
+        self::assertEquals('Meta description', $module->site->meta_description);
+        self::assertEquals('Title', $module->site->title);
+    }
+
+    #[After]
+    public function cleanUpTempFiles(): void
+    {
+        foreach ($this->temp_ini_files as $filename) {
+            unlink($filename);
+        }
+
+        $this->temp_ini_files = [];
+    }
+
+    private function getTempIniFile(string $ini_contents): string
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'ini_test_');
+        file_put_contents($filename, $ini_contents);
+
+        $this->temp_ini_files[] = $filename;
+
+        return $filename;
     }
 }

--- a/tests/Site/SiteConfigModuleTest.php
+++ b/tests/Site/SiteConfigModuleTest.php
@@ -99,6 +99,25 @@ class SiteConfigModuleTest extends TestCase
         self::assertEquals('Environment title', $module->site->title);
     }
 
+    #[Test]
+    public function throwsErrorWhenOverridingArrayWithEnvVar(): void
+    {
+        $this->expectException(SiteException::class);
+        $this->expectExceptionMessage(
+            'Environment variables can only override scalar or null config '
+            . 'values. Defined config for "site.emails" is array.'
+        );
+
+        $app = Mockery::mock(SiteApplication::class);
+
+        $module = new SiteConfigModule($app);
+        $module->addDefinitions([
+            'site.emails' => ['test@example.com', 'foo@example.com'],
+        ]);
+        $this->setEnvVar('SITE_EMAILS', 'bar@example.com');
+        $module->load($this->getTempIniFile(''));
+    }
+
     #[After]
     public function cleanUpTempFiles(): void
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
# Description

Updates SiteConfigModule to allow parsing config values from env vars. Adds unit tests and stricter types.

# Testing Instructions (optional)

Add step-by-step instructions for testing the PR, if necessary.

1. Check out this PR
2. …

# Developer Checklist

Before requesting review for this PR, make sure the following tasks are
complete:

- [ ] I added a link to the relevant Shortcut story, if applicable
- [x] I added testing instructions, if any
- [x] I made sure existing CI checks pass
- [x] I checked that all requirements of the ticket are fulfilled

# Reviewer Checklist

Before merging this PR, make sure the following tasks are complete:

- [ ] I made sure there are no active labels that block merge
- [ ] I followed the testing instructions
- [ ] I made sure the CI checks pass
- [ ] I reviewed the file changes on GitHub
- [ ] I checked that all requirements of the ticket (if any) are fulfilled
