### PR TITLE
Add missing resource declarations so they get sorted properly when used by sites

### DIFF
--- a/dependencies/site.yaml
+++ b/dependencies/site.yaml
@@ -25,20 +25,25 @@ Site:
 
   Provides:
     # JavaScript resources
-    packages/site/javascript/site-gravatar-entry.js:
-    packages/site/javascript/site-tag-entry.js:
-    packages/site/javascript/site-upload-progress-bar.js:
     packages/site/javascript/site-content-slider.js:
+    packages/site/javascript/site-dialog.js:
+    packages/site/javascript/site-gravatar-entry.js:
+    packages/site/javascript/site-jw-player-media-display.js:
+    packages/site/javascript/site-tag-entry.js:
     packages/site/admin/javascript/site-comment-display.js:
     packages/site/admin/javascript/site-comment-status-slider.js:
 
     # Style-sheet resources
     packages/site/styles/site-account-login-page.css:
     packages/site/styles/site-account-reset-password-page.css:
+    packages/site/styles/site-admin-forgot-password-page.css:
     packages/site/styles/site-contact-page.css:
+    packages/site/styles/site-content-slider.css:
     packages/site/styles/site-image-cell-renderer.css:
+    packages/site/styles/site-jw-player-media-display.css:
     packages/site/styles/site-search-results-page.css:
     packages/site/styles/site-tag-entry.css:
-    packages/site/styles/site-content-slider.css:
+    packages/site/admin/styles/site-account-merge.css:
     packages/site/admin/styles/site-comment-display.css:
     packages/site/admin/styles/site-comment-status-slider.css:
+    packages/site/admin/styles/site-image-upload.css:


### PR DESCRIPTION
# Description

The resources need to be declared to "belong" to the package properly. The package is used to set the sorting order for the final bundled assets or included assets on the page. If the resource is not declared, it becomes part of the default `__site__` package and the sorting order may be incorrect.

# Testing Instructions (optional)

Add step-by-step instructions for testing the PR, if necessary.

1. Review the list of CSS and JS assets and compare with the YAML file.

# Developer Checklist

Before requesting review for this PR, make sure the following tasks are
complete:

- [ ] I added a link to the relevant Shortcut story, if applicable
- [x] I added testing instructions, if any
- [ ] I made sure existing CI checks pass
- [x] I checked that all requirements of the ticket are fulfilled

# Reviewer Checklist

Before merging this PR, make sure the following tasks are complete:

- [ ] I made sure there are no active labels that block merge
- [ ] I followed the testing instructions
- [ ] I made sure the CI checks pass
- [ ] I reviewed the file changes on GitHub
- [ ] I checked that all requirements of the ticket (if any) are fulfilled
